### PR TITLE
namespace fix in registration login tpl

### DIFF
--- a/bluebottle/accounts/templates/registration/login.html
+++ b/bluebottle/accounts/templates/registration/login.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="modal" id="loginModal">
-    <form id="login-form" action="{% url 'login' %}" method="post">
+    <form id="login-form" action="{% url 'accounts:login' %}" method="post">
         
         <div class="modal-header">
             {% block login_header %}


### PR DESCRIPTION
Django's contrib.auth app uses templates/registration/ for its templates.
