### PR TITLE
Userprofile editing updates

### DIFF
--- a/bluebottle/accounts/serializers.py
+++ b/bluebottle/accounts/serializers.py
@@ -3,7 +3,7 @@ from django import forms
 
 from rest_framework import serializers
 
-from bluebottle.bluebottle_drf2.serializers import SorlImageField, ImageSerializer, TagSerializer
+from bluebottle.bluebottle_drf2.serializers import (SorlImageField, ImageSerializer, TagSerializer, TaggableSerializerMixin)
 from bluebottle.utils.serializers import URLField
 from bluebottle.utils.validators import validate_postal_code
 from bluebottle.geo.models import Country
@@ -65,14 +65,7 @@ class UserStatisticsMixin(object):
         return result
 
 
-class SkillSerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = Skill
-        fields = ('id', 'name')
-
-
-class UserProfileSerializer(UserStatisticsMixin, serializers.ModelSerializer):
+class UserProfileSerializer(UserStatisticsMixin, TaggableSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for a member's public profile.
     """
@@ -86,7 +79,7 @@ class UserProfileSerializer(UserStatisticsMixin, serializers.ModelSerializer):
     # TODO: extend this serializer with abstract base model
     skill_ids = serializers.PrimaryKeyRelatedField(many=True, source='skills')
     favourite_country_ids = serializers.PrimaryKeyRelatedField(many=True, source="favourite_countries")
-    favourite_themes = serializers.PrimaryKeyRelatedField(many=True)
+    favourite_theme_ids = serializers.PrimaryKeyRelatedField(many=True, source="favourite_themes")
     tags = TagSerializer()
 
     user_statistics = serializers.SerializerMethodField('get_user_statistics')
@@ -95,7 +88,7 @@ class UserProfileSerializer(UserStatisticsMixin, serializers.ModelSerializer):
         model = BlueBottleUser
         #TODO: add       * interested in target groups
         fields = ('id', 'url', 'username', 'first_name', 'last_name', 'picture', 'about', 'why', 'website',
-                  'availability', 'date_joined', 'location', 'skill_ids', 'favourite_country_ids', 'favourite_themes',
+                  'availability', 'date_joined', 'location', 'skill_ids', 'favourite_country_ids', 'favourite_theme_ids',
                   'tags', 'user_statistics')
 
 

--- a/bluebottle/accounts/static/js/bluebottle/accounts/components.js
+++ b/bluebottle/accounts/static/js/bluebottle/accounts/components.js
@@ -6,13 +6,11 @@ App.BbMultipleSelectedItemsComponent = Ember.Component.extend({
 		var item = obj.find(this.get("selectedItem") );
 		this.get("selectedItems").addObject(item);
 
+
 	}.observes("selectedItem"),
 
 	actions: {
 		removeItem: function(item){
-			console.log("item clicked");
-			console.log(item);
-			console.log(this.get("selectedItems").toString());
 			this.get("selectedItems").removeObject(item);
 		}
 	}

--- a/bluebottle/accounts/static/js/bluebottle/accounts/controllers.js
+++ b/bluebottle/accounts/static/js/bluebottle/accounts/controllers.js
@@ -64,8 +64,11 @@ App.UserProfileController = Ember.ObjectController.extend(App.Editable, {
 
     allCountries: function(){
         return App.Country.find();
-    }.property()
+    }.property(),
 
+    allThemes: function(){
+        return App.Theme.find();
+    }.property()
 
 });
 

--- a/bluebottle/accounts/static/js/bluebottle/accounts/models.js
+++ b/bluebottle/accounts/static/js/bluebottle/accounts/models.js
@@ -33,7 +33,9 @@ App.User = DS.Model.extend({
     password: DS.attr('string'),
 
     favourite_countries: DS.hasMany("App.Country"),
+    favourite_themes: DS.hasMany("App.Theme"),
 
+    tags: DS.hasMany("App.Tag", {embedded: "always"}),
 
     getPicture: function() {
         if (this.get('picture')) {
@@ -61,6 +63,7 @@ App.User = DS.Model.extend({
     }.property('date_joined'),
 
 });
+
 
 
 // TODO: split this of

--- a/bluebottle/accounts/templates/accounts/profile_form.hbs
+++ b/bluebottle/accounts/templates/accounts/profile_form.hbs
@@ -34,15 +34,21 @@
                             {# TODO: Error Handling #}
                         </li>
                       
-                       {{bb-multiple-selected-items selected_label="Selected skills" selectedItems=skills availableItems=allSkills type="Skill" available_label="Available skills" }}
+                       {{bb-multiple-selected-items selected_label="Selected skills" selectedItems=skills availableItems=allSkills type="Skill" available_label="Available skills"}}
 
-                       {{#each country in favourite_countries}}
-                            {{ country }} 
-                       {{/each}}
+                       {{bb-multiple-selected-items selected_label="Selected Countries" selectedItems=favourite_countries availableItems=allCountries type="Country" available_label="Available Countries"}}
 
-                        {{bb-multiple-selected-items selected_label="Selected Countries" selectedItems=favourite_countries availableItems=allCountries type="Country" available_label="Available Countries" }}
+                       {{bb-multiple-selected-items selected_label="Selected Themes" selectedItems=favourite_themes availableItems=allThemes type="Theme" available_label="Available Themes"}}
 
-                        {{ bb-upload-image hint='Upload profile picture' fileBinding=image image_url=image.large label='Profile Picture' buttonLabel='Upload picture' errors=errors.image }}
+                    <fieldset>
+                        <ul>
+                            {{#bb-form-field hint='Add some tags' label='Tags' errors=errors.tags}}
+                                {{view App.TagWidget tagsBinding="tags" classBinding="errors.tags.length:error"}}
+                            {{/bb-form-field}}
+                        </ul>
+                    </fieldset>
+
+                    {{ bb-upload-image hint='Upload profile picture' fileBinding=image image_url=image.large label='Profile Picture' buttonLabel='Upload picture' errors=errors.image }}
 
                     </ul>
                 </fieldset>

--- a/bluebottle/bluebottle_drf2/serializers.py
+++ b/bluebottle/bluebottle_drf2/serializers.py
@@ -368,7 +368,8 @@ class TaggableSerializerMixin(object):
         # If there are tags sent to the API then store them and wipe them from data
         # to avoid DRF2 nested serializer trying to store them.
         instance = super(TaggableSerializerMixin, self).from_native(data, files)
-        if 'tags' in data:
+
+        if data and 'tags' in data:
             self.tag_list = data['tags']
         if instance:
             return self.full_clean(instance)

--- a/bluebottle/common/static/js/bluebottle/app.js
+++ b/bluebottle/common/static/js/bluebottle/app.js
@@ -188,7 +188,8 @@ App.Adapter = DS.DRF2Adapter.extend({
 
 // Assigning plurals for model properties doesn't seem to work with extend, it does this way:
 App.Adapter.configure("plurals", {
-    "address": "addresses"
+    "address": "addresses",
+    "favourite_country" : "favourite_countries"
 });
 
 App.ApplicationController = Ember.Controller.extend({

--- a/bluebottle/common/static/js/vendor/ember-data-drf2-adapter.js
+++ b/bluebottle/common/static/js/vendor/ember-data-drf2-adapter.js
@@ -102,24 +102,39 @@ DS.DRF2Serializer = DS.RESTSerializer.extend({
         }, this);
     },
 
+    
+    
+    /**
+    Customize the serializer to also send PrimaryRelatedFields ids.
+    http://stackoverflow.com/questions/16128525/customizing-what-ember-data-sends-to-the-server
+    */
     addHasMany: function(hash, record, key, relationship){
 
-        //Er moet een check op voor "embedded" zodat dit alleen gedaan wordt voor "niet embeddded" items
-
-
-        console.log("Hash: ", hash);
+        /*console.log("Hash: ", hash);
         console.log("Record: ", record);
         console.log("Key: ", key);
         console.log("Relationship: ", relationship);
-        console.log("Relationship key: ", relationship.key);
+        console.log("Relationship key: ", relationship.key);*/
 
         var ids = record.get(relationship.key).map(function(item){
-            console.log("Item: ", item);
             return item.id;
         });
-        console.log("Ids: ", ids);
-        hash[key] = ids;
-    }
+
+        if (relationship.key != "tags") {
+            hash[key] = ids;
+        } else {
+            
+            var tags = record.get(relationship.key).map(function(item){
+                //console.log("Item: ", item);
+                return {"id" : item.id };
+            });
+            //console.log("Tags", tags);
+            hash[relationship.key] = tags;
+        }
+    },
+    
+
+
 });
 
 
@@ -362,11 +377,14 @@ DS.DRF2Adapter = DS.RESTAdapter.extend({
     },
 
     /**
-        Temp
+        Taken from Stackoverflow to mark changed hasMany Ember relations as dirty
     */
     dirtyRecordsForHasManyChange: function(dirtySet, record, relationship) {
-      relationship.childReference.parent = relationship.parentReference;
-      this._dirtyTree(dirtySet, record);
+        /*console.log("dirtyset: ", dirtySet);
+        console.log("record: ", record);
+        console.log("relationship", relationship);*/
+        relationship.childReference.parent = relationship.parentReference;
+        this._dirtyTree(dirtySet, record);
     },
 });
 

--- a/bluebottle/projects/admin.py
+++ b/bluebottle/projects/admin.py
@@ -1,4 +1,4 @@
-from bluebottle.projects.models import ProjectPhase, ProjectDetailField, ProjectDetailFieldAttribute, ProjectDetailFieldValue, ProjectDetail
+from bluebottle.projects.models import ProjectPhase, ProjectDetailField, ProjectDetailFieldAttribute, ProjectDetailFieldValue, ProjectDetail, ProjectTheme
 from django.contrib import admin
 from django.core.urlresolvers import reverse
 from django.utils.html import escape
@@ -13,6 +13,10 @@ from .models import Project
 
 
 logger = logging.getLogger(__name__)
+
+class ProjectThemeAdmin(admin.ModelAdmin):
+    model = ProjectTheme
+admin.site.register(ProjectTheme, ProjectThemeAdmin)
 
 
 class ProjectDetailAdmin(admin.StackedInline):

--- a/bluebottle/projects/serializers.py
+++ b/bluebottle/projects/serializers.py
@@ -92,11 +92,11 @@ class ManageProjectSerializer(TaggableSerializerMixin, serializers.ModelSerializ
 
 
 class ProjectThemeSerializer(serializers.ModelSerializer):
-    title = serializers.Field(source='name')
+    #title = serializers.Field(source='name')
 
     class Meta:
         model = ProjectTheme
-        fields = ('id', 'title')
+        fields = ('id', 'name')
         
         
 class ProjectBudgetLineSerializer(serializers.ModelSerializer):

--- a/bluebottle/projects/static/js/bluebottle/projects/models.js
+++ b/bluebottle/projects/static/js/bluebottle/projects/models.js
@@ -204,7 +204,7 @@ App.ProjectDonation = DS.Model.extend({
 
 App.Theme = DS.Model.extend({
     url:'projects/themes',
-    title: DS.attr('string')
+    name: DS.attr('string'),
 });
 
 App.ThemeList = [


### PR DESCRIPTION
User profile can now be edited with:
- Skills
- Themes
- Countries
- Tags (not fully functional)

This update includes the overriden "hasMany" and "dirtyRecrodsForHasManyChange" functions to change many2many relations via Ember and the api. The current functions do not break the implementation of the tagging Mixin of the API. However, the tags in a user profile are not loaded properly via Ember. They are saved correctly to the API.

The update also changes the serializer for the ProjectTheme model. Instead of a "title" field the serializer now consistently uses the "name" field of the model. 
