### PR TITLE
Revert some changes to filter_fields in serialiser

### DIFF
--- a/bluebottle/bb_tasks/views.py
+++ b/bluebottle/bb_tasks/views.py
@@ -17,6 +17,7 @@ class TaskPreviewList(generics.ListAPIView):
     model = BB_TASK_MODEL
     serializer_class = TaskPreviewSerializer
     paginate_by = 8
+    filter_fields = ('status', 'skill', )
 
     def get_queryset(self):
         qs = super(TaskPreviewList, self).get_queryset()
@@ -35,14 +36,6 @@ class TaskPreviewList(generics.ListAPIView):
                            Q(description__icontains=text) |
                            Q(end_goal__icontains=text))
 
-        skill = self.request.QUERY_PARAMS.get('skill', None)
-        if skill:
-            qs = qs.filter(skill=skill)
-
-        status = self.request.QUERY_PARAMS.get('status', None)
-        if status:
-            qs = qs.filter(status=status)
-
         ordering = self.request.QUERY_PARAMS.get('ordering', None)
 
         if ordering == 'newest':
@@ -59,13 +52,10 @@ class TaskList(DefaultSerializerMixin, generics.ListCreateAPIView):
     model = BB_TASK_MODEL
     paginate_by = 8
     permission_classes = (IsProjectOwnerOrReadOnly,)
+    filter_fields = ('status', )
 
     def get_queryset(self):
         qs = super(TaskList, self).get_queryset()
-
-        status = self.request.QUERY_PARAMS.get('status', None)
-        if status:
-            qs = qs.filter(status=status)
 
         project_slug = self.request.QUERY_PARAMS.get('project', None)
         if project_slug:

--- a/bluebottle/news/views.py
+++ b/bluebottle/news/views.py
@@ -7,15 +7,10 @@ class NewsItemPreviewList(generics.ListAPIView):
     model = NewsItem
     serializer_class = NewsItemPreviewSerializer
     paginate_by = 5
+    filter_fields = ('language', )
 
     def get_queryset(self, *args, **kwargs):
         qs = super(NewsItemPreviewList, self).get_queryset()
-        
-        # Set language if supplied
-        language = self.request.QUERY_PARAMS.get('language', None)
-        if language:
-            qs = qs.filter(language=language)
-
         qs = qs.published()
         return qs
 
@@ -24,15 +19,10 @@ class NewsItemList(generics.ListAPIView):
     model = NewsItem
     serializer_class = NewsItemSerializer
     paginate_by = 5
+    filter_fields = ('language', )
 
     def get_queryset(self, *args, **kwargs):
-        qs = super(NewsItemList, self).get_queryset()
-
-        # Set language if supplied
-        language = self.request.QUERY_PARAMS.get('language', None)
-        if language:
-            qs = qs.filter(language=language)
-
+        qs = super(NewsItemList, self).get_queryset() 
         qs = qs.published()
         return qs
 

--- a/bluebottle/pages/tests/test_api.py
+++ b/bluebottle/pages/tests/test_api.py
@@ -42,8 +42,6 @@ class PageListTestCase(PageTestCase):
 		response = self.client.get(reverse('page_list', kwargs={'language': 'nl'}))
 
 		self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-
 		self.assertEqual(response.data['count'], 1)
 
 

--- a/bluebottle/quotes/views.py
+++ b/bluebottle/quotes/views.py
@@ -11,15 +11,10 @@ class QuoteList(generics.ListAPIView):
     model = Quote
     serializer_class = QuoteSerializer
     paginate_by = 10
+    filter_fields = ('language',) 
 
     def get_queryset(self):
         qs = super(QuoteList, self).get_queryset()
-
-        # Set language if supplied
-        language = self.request.QUERY_PARAMS.get('language', None)
-        if language:
-            qs = qs.filter(language=language)
-
         qs = qs.filter(status=Quote.QuoteStatus.published)
         qs = qs.filter(publication_date__lte=now)
         qs = qs.filter(Q(publication_end_date__gte=now) | Q(publication_end_date__isnull=True))

--- a/bluebottle/settings/base.py
+++ b/bluebottle/settings/base.py
@@ -120,6 +120,15 @@ MIDDLEWARE_CLASSES = (
 )
 
 
+REST_FRAMEWORK = {
+    # Don't do basic authentication.
+    'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.SessionAuthentication',
+    ),
+}
+
+
 INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/bluebottle/slides/views.py
+++ b/bluebottle/slides/views.py
@@ -12,15 +12,10 @@ class SlideList(generics.ListAPIView):
     serializer_class = SlideSerializer
     permissions_classes = (permissions.SAFE_METHODS,)
     paginate_by = 10
+    filter_fields = ('language', )
 
     def get_queryset(self):
         qs = super(SlideList, self).get_queryset()
-
-        # Set language if supplied
-        language = self.request.QUERY_PARAMS.get('language', None)
-        if language:
-            qs = qs.filter(language=language)
-
         qs = qs.filter(status=Slide.SlideStatus.published)
         qs = qs.filter(publication_date__lte=now)
         qs = qs.filter(Q(publication_end_date__gte=now) | Q(publication_end_date__isnull=True))


### PR DESCRIPTION
Previous failed test were due to missing settings for the rest framework.
