### PR TITLE
Fix for using the google static map api

### DIFF
--- a/bluebottle/common/static/js/bluebottle/mixins.js
+++ b/bluebottle/common/static/js/bluebottle/mixins.js
@@ -171,7 +171,7 @@ App.StaticMapMixin = Em.Mixin.create({
             "&markers=color:pink%7Clabel:P%7C" + latlng + "&sensor=false";
 
         if (MAPS_API_KEY)
-            imageUrl += "?key=" + MAPS_API_KEY;
+            imageUrl += "&key=" + MAPS_API_KEY;
 
         return imageUrl;
     }.property('latitude', 'longitude')

--- a/bluebottle/utils/context_processors.py
+++ b/bluebottle/utils/context_processors.py
@@ -24,3 +24,13 @@ def google_analytics_code(request):
     except AttributeError:
         context ={}
     return context
+
+def google_maps_api_key(request):
+    """
+    Add Google Maps API key from settings file to general request context.
+    """
+    try:
+        context = {'MAPS_API_KEY': settings.MAPS_API_KEY}
+    except AttributeError:
+        context = {}
+    return context


### PR DESCRIPTION
Add 'bluebottle.utils.context_processors.google_maps_api_key' to context processors if a google maps api will be used for static maps.
