### PR TITLE
Change to api access for project status

### DIFF
--- a/bluebottle/bb_projects/views.py
+++ b/bluebottle/bb_projects/views.py
@@ -128,15 +128,50 @@ class ManageProjectList(ManageSerializerMixin, generics.ListCreateAPIView):
         """
         Set the project owner and the status of the project.
         """
-        print "pre_saving: ", obj
         obj.status = ProjectPhase.objects.order_by('sequence').all()[0]
-        print ProjectPhase.objects.order_by('sequence').all()[0]
         obj.owner = self.request.user
 
 
 class ManageProjectDetail(ManageSerializerMixin, generics.RetrieveUpdateAPIView):
     model = PROJECT_MODEL
     permission_classes = (IsProjectOwner, )
+
+    def get_object(self):
+        # Call the superclass
+        object = super(ManageProjectDetail, self).get_object()
+
+        # store the current state
+        self.current_status = object.status
+
+        return object
+
+    """
+    Don't let the owner set a status with a sequence number higher than 2 
+    They can set 1: plan-new or 2: plan-submitted
+
+    TODO: This needs work. Maybe we could use a FSM for the project status
+          transitions, e.g.: 
+              https://pypi.python.org/pypi/django-fsm/1.2.0
+    """
+    def pre_save(self, obj):
+        submit_status = ProjectPhase.objects.get(slug='plan-submitted')
+        status_id = self.request.DATA.get('status')
+
+        """
+        TODO: what to do if the expected status (plan-submitted) is
+              no found?! Hard fail?
+        """
+        if submit_status and status_id:
+            max_sequence = submit_status.sequence
+            new_status = ProjectPhase.objects.get(id=status_id)
+
+            """
+            Reset the status if the owner is trying to set the status
+            higher than the max permitted, or the user is trying to
+            set the status back to a lower state
+            """
+            if new_status and (new_status.sequence > max_sequence or new_status.sequence < self.current_status.sequence):
+                obj.status = self.current_status
 
 
 class ProjectThemeList(generics.ListAPIView):


### PR DESCRIPTION
Restrict updating of project status by project owner to the first two - plan-new and plan-submitted
