### PR TITLE
Add organization to the default BB serializer for project/manage

### DIFF
--- a/bluebottle/bb_projects/serializers.py
+++ b/bluebottle/bb_projects/serializers.py
@@ -91,5 +91,5 @@ class ManageProjectSerializer(TaggableSerializerMixin, serializers.ModelSerializ
     class Meta:
         model = PROJECT_MODEL
         fields = ('id', 'title', 'description', 'editable', 'viewable', 'status', 'image', 'pitch',
-                  'slug', 'tags', 'created', 'url', 'country', 'theme')
+                  'slug', 'tags', 'created', 'url', 'country', 'theme', 'organization')
 


### PR DESCRIPTION
This is needed when creating a new project in the frontend.
