### PR TITLE
Require tab step when calling goToStep

### DIFF
--- a/bluebottle/bb_projects/static/js/bluebottle/bb_projects/controllers.js
+++ b/bluebottle/bb_projects/static/js/bluebottle/bb_projects/controllers.js
@@ -284,7 +284,7 @@ App.MyProjectListController = Em.ArrayController.extend({
 
 });
 
-App.MyProjectController = Em.ObjectController.extend({
+App.MyProjectController = Em.ObjectController.extend(App.SaveOnExitMixin, {
     needs: ['currentUser', 'myProjectOrganisation'],
 
     // Create a one way binding so that changes in the MyProject controller don't alter the value in

--- a/bluebottle/bb_projects/static/js/bluebottle/bb_projects/routes.js
+++ b/bluebottle/bb_projects/static/js/bluebottle/bb_projects/routes.js
@@ -127,12 +127,6 @@ App.MyProjectSubRoute = Em.Route.extend(App.ScrollToTop, {
 
     model: function(params) {
         return this.modelFor('myProject');
-    },
-
-    deactivate: function() {
-        if (!this.skipExitSignal) {
-            this.get('controller').send('goToStep');
-        }
     }
 });
 
@@ -197,12 +191,6 @@ App.MyProjectOrganisationRoute = Em.Route.extend({
             return project.get('organization');
         } else {
             return App.MyOrganization.createRecord();
-        }
-    },
-    
-    deactivate: function() {
-        if (!this.skipExitSignal) {
-            this.get('controller').send('goToStep');
         }
     },
 

--- a/bluebottle/bb_projects/templates/bb_projects/manage/main.hbs
+++ b/bluebottle/bb_projects/templates/bb_projects/manage/main.hbs
@@ -34,42 +34,52 @@
                     </div>
                     <ul id="campaign-steps" class="{{#if isPhasePlanNew}} steps {{else}} tabs {{/if}}">
                         {{#if isPhasePlanNew}}
-                            <li class="tab">{{#link-to "myProject.start" classBinding=":tab-link :validated"}}
-                                {{#if validStart}}
-                                    <span class="flaticon solid checkmark-1 "></span>
-                                {{/if}}
-                                {% trans "Start" %}
-                            {{/link-to}}</li>
+                            <li class="tab" {{action goToStep "myProject.start"}}>
+                                {{#link-to "myProject.start" classBinding=":tab-link :validated"}}
+                                    {{#if validStart}}
+                                        <span class="flaticon solid checkmark-1 "></span>
+                                    {{/if}}
+                                    {% trans "Start" %}
+                                {{/link-to}}
+                            </li>
                         {{/if}}
 
-                        <li class="tab">{{#link-to "myProject.pitch" classBinding=":tab-link validPitch:validated"}}
-                            {{#if validPitch}}
-                                {{#if isPhasePlanNew}}<span class="flaticon solid checkmark-1"></span>{{/if}}
-                            {{/if}}
-                            {% trans "Project" %}
-                        {{/link-to}}</li>
+                        <li class="tab" {{action goToStep "myProject.pitch"}}>
+                            {{#link-to "myProject.pitch" classBinding=":tab-link validPitch:validated"}}
+                                {{#if validPitch}}
+                                    {{#if isPhasePlanNew}}<span class="flaticon solid checkmark-1"></span>{{/if}}
+                                {{/if}}
+                                {% trans "Project" %}
+                            {{/link-to}}
+                        </li>
 
-                        <li class="tab">{{#link-to "myProject.story" classBinding=":tab-link validStory:validated"}}
-                            {{#if validStory}}
-                                {{#if isPhasePlanNew}}<span class="flaticon solid checkmark-1"></span>{{/if}}
-                            {{/if}}
-                            {% trans "Description" %}
-                        {{/link-to}}</li>
+                        <li class="tab" {{action goToStep "myProject.story"}}>
+                            {{#link-to "myProject.story" classBinding=":tab-link validStory:validated"}}
+                                {{#if validStory}}
+                                    {{#if isPhasePlanNew}}<span class="flaticon solid checkmark-1"></span>{{/if}}
+                                {{/if}}
+                                {% trans "Description" %}
+                            {{/link-to}}
+                        </li>
 
-                        <li class="tab">{{#link-to "myProject.organisation" classBinding=":tab-link validOrganization:validated"}}
-                            {{#if validOrganization}}
-                                {{#if isPhasePlanNew}}<span class="flaticon solid checkmark-1"></span>{{/if}}
-                            {{/if}}
-                            {% trans "Organisation" %}
-                        {{/link-to}}</li>
+                        <li class="tab" {{action goToStep "myProject.organisation"}}>
+                            {{#link-to "myProject.organisation" classBinding=":tab-link validOrganization:validated"}}
+                                {{#if validOrganization}}
+                                    {{#if isPhasePlanNew}}<span class="flaticon solid checkmark-1"></span>{{/if}}
+                                {{/if}}
+                                {% trans "Organisation" %}
+                            {{/link-to}}
+                        </li>
 
                         {{#if this.controller.isSubmittable}}
-                           <li class="tab">{{#link-to "myProject.submit" classBinding=":tab-link validSubmit:validated"}}
-                                {{#if validsubmit}}
-                                    <span class="flaticon solid checkmark-1"></span>
-                                {{/if}}
-                                {% trans "Submit" %}
-                            {{/link-to}}</li>
+                            <li class="tab" {{action goToStep "myProject.submit"}}>
+                                {{#link-to "myProject.submit" classBinding=":tab-link validSubmit:validated"}}
+                                    {{#if validsubmit}}
+                                        <span class="flaticon solid checkmark-1"></span>
+                                    {{/if}}
+                                    {% trans "Submit" %}
+                                {{/link-to}}
+                            </li>
                         {{/if}}
 
                     </ul>

--- a/bluebottle/common/static/js/bluebottle/mixins.js
+++ b/bluebottle/common/static/js/bluebottle/mixins.js
@@ -5,28 +5,32 @@
  */
 App.SaveOnExitMixin = Ember.Mixin.create({
     actions : {
-        goToStep: function(step){
+        goToStep: function(step) {
+            if (!step) {
+                throw new Ember.Logger.error('You should not call `goToStep` without a step.', this); 
+            }
+
             $("body").animate({ scrollTop: 0 }, 600);
             var model = this.get('model');
             var controller = this;
 
             if (!model.get('isDirty')) {
-                if (step) controller.transitionToRoute(step);
+                controller.transitionToRoute(step);
             }
 
             if (model.get('isNew')) {
                 model.one('didCreate', function(){
-                    if (step) controller.transitionToRoute(step);
+                    controller.transitionToRoute(step);
                 });
             } else {
                 model.one('didUpdate', function(){
-                    if (step) controller.transitionToRoute(step);
+                    controller.transitionToRoute(step);
                 });
             }
 
             // If there is a flash property on the controller then 
             // reset as we are changing steps now
-            if (this.get('flash') && step)
+            if (this.get('flash'))
                 this.set('flash', null);
 
             // The class using this mixin must have an implementation of _save()


### PR DESCRIPTION
Also update project create tabs to use action/goToStep. 
Note: keeping the link-to in the tabs for seo

This change also prevents the project being saved twice when using the next / previous links.
