### PR TITLE
Return the email_confirmation in the api serializer when creating a new user CLUB-672

### DIFF
--- a/bluebottle/bb_accounts/models.py
+++ b/bluebottle/bb_accounts/models.py
@@ -271,6 +271,10 @@ class BlueBottleBaseUser(AbstractBaseUser, PermissionsMixin):
     def short_name(self):
         return self.get_short_name()
 
+    @property
+    def email_confirmation(self):
+        return self.email
+
     def reset_disable_token(self):
         token = uuid.uuid4().hex #Generates a random UUID and converts it to a 32-character hexidecimal string
         self.disable_token = token

--- a/bluebottle/bb_accounts/serializers.py
+++ b/bluebottle/bb_accounts/serializers.py
@@ -122,13 +122,14 @@ class UserCreateSerializer(serializers.ModelSerializer):
     editing or viewing users.
     """
     email = serializers.EmailField(required=True, max_length=254)
+    email_confirmation = serializers.EmailField(required=False, max_length=254)
     password = PasswordField(required=True, max_length=128)
     username = serializers.CharField(read_only=True)
     jwt_token = serializers.CharField(source='get_jwt_token', read_only=True)
 
     class Meta:
         model = BB_USER_MODEL
-        fields = ('id', 'username', 'first_name', 'last_name', 'email', 'password', 'jwt_token')
+        fields = ('id', 'username', 'first_name', 'last_name', 'email', 'password', 'jwt_token', 'email_confirmation')
 
 
 class PasswordResetSerializer(serializers.Serializer):


### PR DESCRIPTION
This is so the ember bindings don't kick in and cause the email confirmation field to be cleared when the create user returns the user without the email_confirmation field. This was causing an email mismatch validation error which in turn displayed an error message before the modal would close.
