### PR TITLE
Fix mail subjects for wallposts

### DIFF
--- a/bluebottle/wallposts/mails.py
+++ b/bluebottle/wallposts/mails.py
@@ -64,7 +64,7 @@ def new_wallpost_notification(sender, instance, created, **kwargs):
         if post_author != project_owner:
             send_mail(
                 template_name='project_wallpost_new.mail',
-                subject=_('%(author)s has left a message on your project page.') % {'author': post_author.full_name},
+                subject=_('%(author)s has left a message on your project page.') % {'author': post_author.short_name},
                 to=project_owner,
 
                 project=project,
@@ -83,7 +83,7 @@ def new_wallpost_notification(sender, instance, created, **kwargs):
 
         # Compose the mail
         translation.activate(receiver.primary_language)
-        subject = _('%(author)s has left a message on your task page.') % {'author': author.full_name}
+        subject = _('%(author)s has left a message on your task page.') % {'author': author.short_name}
         context = Context({'task': task, 'receiver': receiver, 'author': author, 'link': link, 'site': site})
         text_content = get_template('task_wallpost_new.mail.txt').render(context)
         html_content = get_template('task_wallpost_new.mail.html').render(context)
@@ -116,7 +116,7 @@ def new_reaction_notification(sender, instance, created, **kwargs):
             if r.author not in mailed_users:
                 send_mail(
                     template_name='project_wallpost_reaction_same_wallpost.mail',
-                    subject=_('%(author)s commented on a post you reacted on.') % {'author': reaction_author.full_name},
+                    subject=_('%(author)s commented on a post you reacted on.') % {'author': reaction_author.short_name},
                     to=r.author,
 
                     project=project,
@@ -130,7 +130,7 @@ def new_reaction_notification(sender, instance, created, **kwargs):
             if reaction_author not in mailed_users and post_author:
                 send_mail(
                    template_name='project_wallpost_reaction_new.mail',
-                   subject=_('%(author)s commented on your post.') % {'author': reaction_author.full_name},
+                   subject=_('%(author)s commented on your post.') % {'author': reaction_author.short_name},
                    to=post_author,
 
                    project=project,
@@ -144,7 +144,7 @@ def new_reaction_notification(sender, instance, created, **kwargs):
             if project_owner not in mailed_users:
                 send_mail(
                     template_name='project_wallpost_reaction_project.mail',
-                    subject=_('%(author)s commented on your project page.') % {'author': reaction_author.full_name},
+                    subject=_('%(author)s commented on your project page.') % {'author': reaction_author.short_name},
                     to=project_owner,
                     author=reaction_author
                 )
@@ -180,7 +180,7 @@ def new_reaction_notification(sender, instance, created, **kwargs):
             if reaction_author not in mailed_users and post_author:
                 send_mail(
                     template_name='task_wallpost_reaction_new.mail',
-                    subject=_('%(author)s commented on your post.') % {'author': reaction_author.full_name},
+                    subject=_('%(author)s commented on your post.') % {'author': reaction_author.short_name},
                     to=post_author,
                     project=task,
                     link='/go/projects/{0}/tasks/{1}'.format(task.project.slug, task.id),
@@ -193,7 +193,7 @@ def new_reaction_notification(sender, instance, created, **kwargs):
             if task_author not in mailed_users:
                 send_mail(
                     template_name='task_wallpost_reaction_task.mail',
-                    subject=_('%(author)s commented on your task page.') % {'author': reaction_author.full_name},
+                    subject=_('%(author)s commented on your task page.') % {'author': reaction_author.short_name},
                     to=task_author,
                     author=reaction_author
                 )


### PR DESCRIPTION
CLUB-758 #resolve

Subject was wrong because full_name isn't a property but a method on Member model. 
Subject: <bound method Member.full_name of <Member: stichtinglasonrisa@outlook.com>> heeft gereageerd op jouw post.
