### PR TITLE
Don't redirect to homepage after sign-up

### DIFF
--- a/bluebottle/bb_accounts/static/js/bluebottle/bb_accounts/controllers.js
+++ b/bluebottle/bb_accounts/static/js/bluebottle/bb_accounts/controllers.js
@@ -116,7 +116,7 @@ App.SignupController = Ember.ObjectController.extend(BB.ModalControllerMixin, Ap
 
                     // Call the loadNextTransition in case the user was unauthenticated and was
                     // shown the sign in / up modal then they should transition to the requests route
-                    //_this.send('loadNextTransition', '/');
+                    _this.send('loadNextTransition', null);
 
                     // Close the modal
                     _this.send('close');


### PR DESCRIPTION
@rollick can you explain why _this.send('loadNextTransition', '/'); was in? Maybe it was wrong to take it out. But staying on the same page after sign up seems the wanted behaviour. 
