### PR TITLE
Use the 'close' action provided by BB.ModalControllerMixin

### DIFF
--- a/bluebottle/bb_donations/templates/bb_donations/donation_success.hbs
+++ b/bluebottle/bb_donations/templates/bb_donations/donation_success.hbs
@@ -14,9 +14,9 @@
         <div class="top-icon"><img {{bindAttr src="currentUser.getAvatar"}} /></div>
 
         {{#if fundraiser}}
-            {{bb-modal-text-wallpost-new parentType='fundraiser' close="closeModal" parentId=fundraiser.id addWallpost='addWallpost'}}
+            {{bb-modal-text-wallpost-new parentType='fundraiser' close="close" parentId=fundraiser.id addWallpost='addWallpost'}}
         {{else}}
-            {{bb-modal-text-wallpost-new parentType='project' close="closeModal" parentId=project.id addWallpost='addWallpost'}}
+            {{bb-modal-text-wallpost-new parentType='project' close="close" parentId=project.id addWallpost='addWallpost'}}
         {{/if}}
 {{!--         <div class="donation-share">
             <p>{% trans "Be sure to share this campaign with your network" %}</p>


### PR DESCRIPTION
This fixes an issue with the bb-modal-text-wallpost-new including the model as an argument when calling the closeModal action. The closeModal action takes a Ember defer object causing things to break if it is model instead.
