### PR TITLE
Add authorized as a possible status for new payments (it can happen t…

### DIFF
--- a/bluebottle/payments_docdata/adapters.py
+++ b/bluebottle/payments_docdata/adapters.py
@@ -271,15 +271,19 @@ class DocdataPaymentAdapter(BasePaymentAdapter):
             # No payment has been authorized
             statuses = {payment.authorization.status for payment in response.payment}
 
-            if {'NEW', 'STARTED', 'REDIRECTED_FOR_AUTHORIZATION', 'AUTHENTICATED', 'RISK_CHECK_OK'} & statuses:
+            if {'NEW', 'STARTED', 'REDIRECTED_FOR_AUTHORIZATION', 'AUTHENTICATED', 'RISK_CHECK_OK', 'AUTHORIZED'} & statuses:
                 # All these statuses belong are considered new
                 status = StatusDefinition.STARTED
             elif statuses == {'CANCELED', }:
                 # If all of them are cancelled, the whole payment is cancelled
                 # Yes, docdata uses "CANCELED"
                 status = StatusDefinition.CANCELLED
-            else:
+            elif {'RISK_CHECK_FAILED', 'AUTHORIZATION_ERROR', 'AUTHORIZATION_FAILED'} & statuses:
+                # If all of them are cancelled, the whole payment is cancelled
+                # Yes, docdata uses "CANCELED"
                 status = StatusDefinition.FAILED
+            else:
+                status = StatusDefinition.UNKOWN
         else:
             # We have some authorized payments
             if int(totals.totalChargedback) == int(totals.totalRegistered):


### PR DESCRIPTION
…hat nothing is captured, approved nor pending but the status is AUHTORIZED. Explicitly check for failed statuses otherwise set the status to UNKOWN