### PR TITLE
Set the invoice_reference in the save method

### DIFF
--- a/bluebottle/bb_payouts/models.py
+++ b/bluebottle/bb_payouts/models.py
@@ -60,6 +60,12 @@ class InvoiceReferenceMixin(models.Model):
         if save:
             super(InvoiceReferenceMixin, self).save()
 
+    def save(self, *args, **kwargs):
+        super(InvoiceReferenceMixin, self).save(*args, **kwargs)
+        if not self.invoice_reference:
+            self.update_invoice_reference()
+
+
 
 class CompletedDateTimeMixin(models.Model):
     """
@@ -260,9 +266,9 @@ class BaseProjectPayout(PayoutBase):
     @property
     def percent(self):
         if not self.amount_payable: return "-"
-        
+
         return "{}%".format(round(((self.amount_raised - self.amount_payable) / self.amount_raised)*100, 1))
-    
+
     def get_payout_rule(self):
         """
         Override this if you want different payout rules for different circumstances.
@@ -582,7 +588,6 @@ class BaseOrganizationPayout(PayoutBase):
         """
         Calculate values on first creation and generate invoice reference.
         """
-
         if not self.id:
             # No id? Not previously saved
 
@@ -590,10 +595,6 @@ class BaseOrganizationPayout(PayoutBase):
                 # This exists mainly for testing reasons, payouts should
                 # always be created new
                 self.calculate_amounts(save=False)
-
-            if not self.invoice_reference:
-                # Conditionally creat invoice reference
-                self.update_invoice_reference(auto_save=True, save=False)
 
         super(BaseOrganizationPayout, self).save(*args, **kwargs)
 

--- a/bluebottle/bb_payouts/signals.py
+++ b/bluebottle/bb_payouts/signals.py
@@ -13,14 +13,14 @@ logger = logging.getLogger()
 
 
 def _set_properties():
-    # If this signal is being triggered from a cron job then 
+    # If this signal is being triggered from a cron job then
     # the tenant properties will not be loaded. Check below
     # and setup the tenant properties if required.
     from bluebottle.clients import properties
     from django.db import connection
 
     try:
-        tenant = properties.tenant 
+        tenant = properties.tenant
     except AttributeError:
         tenant = connection.tenant
         properties.set_tenant(tenant)
@@ -75,8 +75,6 @@ def create_payout_finished_project(sender, instance, created, **kwargs):
                 if project.is_closed:
                     payout.status = StatusDefinition.SETTLED
 
-                payout.save()
-
                 # # Set payment details
                 try:
                     IBANValidator()(project.account_number)
@@ -90,5 +88,6 @@ def create_payout_finished_project(sender, instance, created, **kwargs):
                 payout.receiver_account_city = project.account_holder_city
                 payout.receiver_account_country = project.account_bank_country
 
-                # Generate invoice reference, saves twice
-                payout.update_invoice_reference(auto_save=True)
+                payout.save()
+
+


### PR DESCRIPTION
The invoice reference for ProjectPayouts was set in a the project's
post_save signal handler. As far as I can tell, that is the only way
that payouts are created. However the database of onepercent contains
payouts that do not have the invoice_reference being set.

By moving this to the save method, we will know for sure that the
invoice reference is set. As far as I can tell, this should always be
the case.