### PR TITLE
Exportdb fixes

### DIFF
--- a/bluebottle/bb_accounts/models.py
+++ b/bluebottle/bb_accounts/models.py
@@ -9,6 +9,7 @@ from django.core.mail.message import EmailMessage
 from django.db import models
 from django.db.models import options as options
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
 from django.core import serializers
@@ -129,7 +130,7 @@ class BlueBottleBaseUser(AbstractBaseUser, PermissionsMixin):
     location = models.ForeignKey('geo.Location', help_text=_('Location'), null=True, blank=True)
     favourite_themes = models.ManyToManyField(ProjectTheme, blank=True, null=True)
     skills = models.ManyToManyField(settings.TASKS_SKILL_MODEL, blank=True, null=True)
-    
+
     # TODO Use generate_picture_filename (or something) for upload_to
     picture = ImageField(_('picture'), upload_to='profiles', blank=True)
 
@@ -295,7 +296,7 @@ class BlueBottleBaseUser(AbstractBaseUser, PermissionsMixin):
         """ Returns the number of donations a user has made """
         return self.get_donations_qs().count()
 
-    @property
+    @cached_property
     def funding(self):
         """ Returns the number of projects a user has donated to """
         return self.get_donations_qs().distinct('project').count()
@@ -308,7 +309,7 @@ class BlueBottleBaseUser(AbstractBaseUser, PermissionsMixin):
         """ Returns the number of donations a user has made """
         return self.get_tasks_qs().aggregate(Sum('time_spent'))['time_spent__sum']
 
-    @property
+    @cached_property
     def sourcing(self):
         return self.get_tasks_qs().distinct('task__project').count()
 

--- a/bluebottle/bb_projects/models.py
+++ b/bluebottle/bb_projects/models.py
@@ -8,6 +8,7 @@ from django.db.models.aggregates import Sum
 from django.db.models.query_utils import Q
 from django.core.urlresolvers import reverse
 from django.contrib.contenttypes.models import ContentType
+from django.utils.functional import cached_property
 
 from sorl.thumbnail import ImageField
 from taggit.managers import TaggableManager
@@ -344,7 +345,7 @@ class BaseProject(models.Model, GetTweetMixin):
         if save:
             self.save()
 
-    @property
+    @cached_property
     def funding(self):
         """
         Return the amount of people funding this project
@@ -353,7 +354,7 @@ class BaseProject(models.Model, GetTweetMixin):
             order__status__in=[StatusDefinition.PENDING, StatusDefinition.SUCCESS]
         ).distinct('order__user').count()
 
-    @property
+    @cached_property
     def sourcing(self):
         taskmembers = get_taskmember_model().objects.filter(
             task__project=self,

--- a/bluebottle/bb_tasks/models.py
+++ b/bluebottle/bb_tasks/models.py
@@ -2,7 +2,6 @@ from bluebottle.utils.model_dispatcher import get_taskmember_model
 from django.conf import settings
 from django.db import models
 import django.db.models.options as options
-
 from django.utils.translation import ugettext as _
 
 from django_extensions.db.fields import (

--- a/bluebottle/exports/forms.py
+++ b/bluebottle/exports/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.conf import settings
 from django.contrib.admin import widgets
 from django.utils.translation import ugettext_lazy as _
 
@@ -8,11 +9,15 @@ class ExportDBForm(forms.Form):
     to_date = forms.DateField(label=_('to date'), widget=widgets.AdminDateWidget)
 
     def clean(self):
-        super(ExportDBForm, self).clean()
-        frm, to = self.cleaned_data.get('from_date'), self.cleaned_data.get('to_date')
+        cleaned_data = super(ExportDBForm, self).clean()
+        frm, to = cleaned_data.get('from_date'), cleaned_data.get('to_date')
         if frm and to:
             if to < frm:
                 raise forms.ValidationError(_('The to date must be later than the from date'))
 
             diff = to - frm
-            import bpdb; bpdb.set_trace()
+            if diff.days > settings.EXPORT_MAX_DAYS:
+                raise forms.ValidationError(
+                    _('The delta between from and to date is limited to %d days') % settings.EXPORT_MAX_DAYS
+                )
+        return cleaned_data

--- a/bluebottle/exports/forms.py
+++ b/bluebottle/exports/forms.py
@@ -1,0 +1,18 @@
+from django import forms
+from django.contrib.admin import widgets
+from django.utils.translation import ugettext_lazy as _
+
+
+class ExportDBForm(forms.Form):
+    from_date = forms.DateField(label=_('from date'), widget=widgets.AdminDateWidget)
+    to_date = forms.DateField(label=_('to date'), widget=widgets.AdminDateWidget)
+
+    def clean(self):
+        super(ExportDBForm, self).clean()
+        frm, to = self.cleaned_data.get('from_date'), self.cleaned_data.get('to_date')
+        if frm and to:
+            if to < frm:
+                raise forms.ValidationError(_('The to date must be later than the from date'))
+
+            diff = to - frm
+            import bpdb; bpdb.set_trace()

--- a/bluebottle/exports/resources.py
+++ b/bluebottle/exports/resources.py
@@ -1,0 +1,34 @@
+from exportdb.exporter import ExportModelResource
+
+
+class DateRangeResource(ExportModelResource):
+    range_field = 'created'
+    select_related = None
+
+    def get_queryset(self):
+        qs = super(DateRangeResource, self).get_queryset()
+        if self.select_related:
+            qs = qs.select_related(*self.select_related)
+        frm, to = self.kwargs.get('from_date'), self.kwargs.get('to_date')
+        return qs.filter(**{'%s__range' % self.range_field: (frm, to)})
+
+
+class UserResource(DateRangeResource):
+    range_field = 'date_joined'
+    select_related = ('location',)
+
+
+class ProjectResource(DateRangeResource):
+    select_related = ('status', 'owner', 'location',)
+
+
+class TaskResource(DateRangeResource):
+    select_related = ('project', 'author', 'location')
+
+
+class TaskMemberResource(DateRangeResource):
+    select_related = ('member', 'task', 'task__project', 'member__location')
+
+
+class DonationResource(DateRangeResource):
+    select_related = ('order', 'order__user', 'order__user__location', 'project', 'fundraiser')

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ install_requires = [
     'django-compressor==1.3',
     'ember-compressor-compiler==0.3.1',
     'django-extensions==1.1.1',
-    'django-exportdb==0.3.3',
+    'django-exportdb==0.4.0',
     'django-filter==0.6',
     'django-geoposition==0.2.2',
     'django-iban==0.2.1',


### PR DESCRIPTION
This is a first set of performance changes/extra features to export the database.

I've added custom ExportResource classes so we can leverage select_related and filter the queryset on a daterange.

Some computed fields on exported objects are cached because they are reused in different properties. This effectively reduces the number of queries.

In a further step I want to look into further reducing the number of queries.