### PR TITLE
Feature/exportdb fixes

### DIFF
--- a/bluebottle/exports/resources.py
+++ b/bluebottle/exports/resources.py
@@ -41,17 +41,43 @@ class TaskResource(DateRangeResource):
     select_related = ('project', 'author', 'location')
 
     def export(self, **kwargs):
-            with temp_disconnect_signal(
-                    signal=post_init,
-                    receiver=task_post_init,
-                    sender=Task,
-                    dispatch_uid='bluebottle.tasks.Task.post_init'):
-                data = super(TaskResource, self).export(**kwargs)
-            return data
+
+        task_signal = dict(
+            signal=post_init,
+            receiver=task_post_init,
+            sender=Task,
+            dispatch_uid='bluebottle.tasks.Task.post_init'
+        )
+        project_signal = dict(
+            signal=post_init,
+            receiver=project_post_init,
+            sender=Project,
+            dispatch_uid='bluebottle.projects.Project.post_init'
+        )
+        with temp_disconnect_signal(**task_signal), temp_disconnect_signal(**project_signal):
+            data = super(TaskResource, self).export(**kwargs)
+        return data
 
 
 class TaskMemberResource(DateRangeResource):
     select_related = ('member', 'task', 'task__project', 'member__location')
+
+    def export(self, **kwargs):
+        task_signal = dict(
+            signal=post_init,
+            receiver=task_post_init,
+            sender=Task,
+            dispatch_uid='bluebottle.tasks.Task.post_init'
+        )
+        project_signal = dict(
+            signal=post_init,
+            receiver=project_post_init,
+            sender=Project,
+            dispatch_uid='bluebottle.projects.Project.post_init'
+        )
+        with temp_disconnect_signal(**task_signal), temp_disconnect_signal(**project_signal):
+            data = super(TaskMemberResource, self).export(**kwargs)
+        return data
 
 
 class DonationResource(DateRangeResource):

--- a/bluebottle/exports/resources.py
+++ b/bluebottle/exports/resources.py
@@ -1,4 +1,10 @@
+from django.db.models.signals import post_init
+
 from exportdb.exporter import ExportModelResource
+
+from bluebottle.projects.models import project_post_init, Project
+from bluebottle.utils.signals import temp_disconnect_signal
+from bluebottle.tasks.models import task_post_init, Task
 
 
 class DateRangeResource(ExportModelResource):
@@ -21,9 +27,27 @@ class UserResource(DateRangeResource):
 class ProjectResource(DateRangeResource):
     select_related = ('status', 'owner', 'location',)
 
+    def export(self, **kwargs):
+        with temp_disconnect_signal(
+                signal=post_init,
+                receiver=project_post_init,
+                sender=Project,
+                dispatch_uid='bluebottle.projects.Project.post_init'):
+            data = super(ProjectResource, self).export(**kwargs)
+        return data
+
 
 class TaskResource(DateRangeResource):
     select_related = ('project', 'author', 'location')
+
+    def export(self, **kwargs):
+            with temp_disconnect_signal(
+                    signal=post_init,
+                    receiver=task_post_init,
+                    sender=Task,
+                    dispatch_uid='bluebottle.tasks.Task.post_init'):
+                data = super(TaskResource, self).export(**kwargs)
+            return data
 
 
 class TaskMemberResource(DateRangeResource):
@@ -31,4 +55,13 @@ class TaskMemberResource(DateRangeResource):
 
 
 class DonationResource(DateRangeResource):
-    select_related = ('order', 'order__user', 'order__user__location', 'project', 'fundraiser')
+    select_related = ('order', 'order__user', 'order__user__location', 'project', 'project', 'fundraiser')
+
+    def export(self, **kwargs):
+        with temp_disconnect_signal(
+                signal=post_init,
+                receiver=project_post_init,
+                sender=Project,
+                dispatch_uid='bluebottle.projects.Project.post_init'):
+            data = super(DonationResource, self).export(**kwargs)
+        return data

--- a/bluebottle/utils/signals.py
+++ b/bluebottle/utils/signals.py
@@ -1,0 +1,28 @@
+
+
+class temp_disconnect_signal(object):
+    """
+    Temporarily disconnect a model from a signal
+    """
+
+    def __init__(self, signal, receiver, sender, dispatch_uid=None):
+        self.signal = signal
+        self.receiver = receiver
+        self.sender = sender
+        self.dispatch_uid = dispatch_uid
+
+    def __enter__(self):
+        self.signal.disconnect(
+            receiver=self.receiver,
+            sender=self.sender,
+            dispatch_uid=self.dispatch_uid,
+            weak=False
+        )
+
+    def __exit__(self, type, value, traceback):
+        self.signal.connect(
+            receiver=self.receiver,
+            sender=self.sender,
+            dispatch_uid=self.dispatch_uid,
+            weak=False
+        )


### PR DESCRIPTION
This PR contains some more database-related optimization.

Project/task signals get temporarily disconnected while exporting the database, leading to less queries. On my local machine I reduced an export from 27s to 16s.

I haven't been able to resolve the 'seems to be stuck at 6%' issue yet.