### PR TITLE
Delay sending to facebook, fix caption and message

### DIFF
--- a/bluebottle/common/tasks.py
+++ b/bluebottle/common/tasks.py
@@ -10,7 +10,7 @@ from urlparse import urljoin
 from celery import shared_task
 from sorl.thumbnail.shortcuts import get_thumbnail
 
-from bluebottle.clients.utils import LocalTenant
+from bluebottle.clients.utils import LocalTenant, tenant_url
 from bluebottle.wallposts.models import MediaWallpost
 
 logger = logging.getLogger()
@@ -142,9 +142,10 @@ def _post_to_facebook(instance, tenant=None):
         data = {
             'link': link,
             'name': instance.content_object.title,
-            'caption': instance.content_object.pitch,
-            'description': instance.text,
-            'picture': image
+            'description': instance.content_object.pitch,
+            'message': instance.text,
+            'picture': image,
+            'caption': tenant_url()
         }
 
         # TODO: log failed requests

--- a/bluebottle/wallposts/signals.py
+++ b/bluebottle/wallposts/signals.py
@@ -18,4 +18,8 @@ def post_to_facebook(sender, instance, created, **kwargs):
         tenant = None
 
     if created and instance.share_with_facebook:
-        _post_to_facebook.delay(instance, tenant=tenant)
+        _post_to_facebook.apply_async(
+            args=[instance],
+            kwargs={'tenant': tenant},
+            countdown=5
+        )


### PR DESCRIPTION
* Delay sending to facebook, since the images are hooked up after the creation of the wallpost. This is a bit of a hack, but fixing the wallpost creation is much, much more work.

* Put the url in the caption, and the message above the image.