### PR TITLE
Automattically fill the slug for categories. 

### DIFF
--- a/bluebottle/categories/models.py
+++ b/bluebottle/categories/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.template.defaultfilters import slugify
 from django.utils.translation import ugettext as _
 
 from bluebottle.utils.fields import ImageField
@@ -25,6 +26,13 @@ class Category(models.Model):
         return self.project_set.order_by('-favorite', '-popularity').filter(
             status__slug__in=['campaign', 'done-complete', 'done-incomplete',
                               'voting', 'voting-done'])
+
+    def save(self, **kwargs):
+        if not self.slug:
+            self.slug = slugify(self.title)
+
+        super(Category, self).save(**kwargs)
+
 
     class Meta:
         verbose_name = _("category")

--- a/bluebottle/categories/tests/test_unit.py
+++ b/bluebottle/categories/tests/test_unit.py
@@ -1,0 +1,15 @@
+from bluebottle.test.utils import BluebottleTestCase
+from bluebottle.test.factory_models.categories import CategoryFactory
+
+
+class TestCategoryModel(BluebottleTestCase):
+    """
+        save() automatically updates some fields, specifically
+        the status field. Make sure it picks the right one
+    """
+    def test_save_slug(self):
+        category = CategoryFactory(title='test-title')
+        category.save()
+
+        self.assertEqual(category.slug, 'test-title')
+


### PR DESCRIPTION
Note that the standard method of prepopulated fields does not work if you exclude the slug field in the admin