### PR TITLE
Make sorl.thumbnail a tenant app

### DIFF
--- a/bluebottle/settings/base.py
+++ b/bluebottle/settings/base.py
@@ -241,7 +241,6 @@ SHARED_APPS = (
     'django_extensions',
     'raven.contrib.django.raven_compat',
     'djcelery',
-    'sorl.thumbnail',
     'micawber.contrib.mcdjango',  # Embedding videos
     'rest_framework',
     'loginas',
@@ -270,6 +269,9 @@ TENANT_APPS = (
     'admin_tools.menu',
     'admin_tools.dashboard',
 
+    # Thumbnails
+    'sorl.thumbnail',
+
     # FB Auth
     'bluebottle.auth',
 
@@ -284,8 +286,6 @@ TENANT_APPS = (
     'bluebottle.widget',
 
     'rest_framework.authtoken',
-
-
 
     # Newly moved BB apps
     'bluebottle.members',

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ dependency_links = [
     'git+https://github.com/onepercentclub/django-bb-salesforce.git@1.2.2#egg=django-bb-salesforce-1.2.2',
     'git+https://github.com/onepercentclub/django-tenant-extras.git@2.0.8#egg=django-tenant-extras-2.0.8',
     'git+https://github.com/onepercentclub/django-token-auth.git@0.3.0#egg=django-token-auth-0.3.0',
+    'git+https://github.com/mariocesar/sorl-thumbnail.git@v12.3#egg=sorl-thumbnail-12.3-github',
     'hg+https://bitbucket.org/jdiascarvalho/django-filetransfers@89c8381764da217d72f1fa396ce3929f0762b8f9#egg=django-filetransfers-0.1.1'
 ]
 
@@ -46,7 +47,7 @@ install_requires = [
     'dkimpy==0.5.6',
     'micawber==0.3.3',
     'requests==2.5.1',
-    'sorl-thumbnail==12.3',
+    'sorl-thumbnail==12.3-github',
     'transifex-client==0.11',
     'django-tools==0.30.0',
     'django-loginas==0.1.9',


### PR DESCRIPTION
When uploading a file with an identical filename on more then one
tenant, sorl thumbnail generates the same kv cache key for all the
files. This means the file can only be retrieved for one of the tenants.
One way to hit this issue is by using facebook to login for more then 1
tenant. Since facebook send the same filename to each tenant, only one
tenant will show a profile image.

This change makes sure we have a separate kv store for each tenant, so
that we do not have these conflicts.

The reason we install sorl from github is that the version on pypi does not have the migrations packaged (and essentially is not django-1.9 compatible.