### PR TITLE
Set task status to closed when an open task exceeds its deadline BB-7538

### DIFF
--- a/bluebottle/projects/management/commands/cron_status_realised.py
+++ b/bluebottle/projects/management/commands/cron_status_realised.py
@@ -80,7 +80,7 @@ class Command(BaseCommand):
             signal
             """
             self.stdout.write("Checking Task deadlines...\n\n")
-            for task in Task.objects.filter(status='in progress',
+            for task in Task.objects.filter(status__in=['in progress', 'open'],
                                             deadline__lt=now()).all():
                 task.deadline_reached()
 

--- a/bluebottle/projects/tests/test_management.py
+++ b/bluebottle/projects/tests/test_management.py
@@ -195,7 +195,7 @@ class TestStatusMC(BluebottleTestCase):
         task2 = Task.objects.get(title='task2')
 
         self.assertEqual(task1.status, 'realized')
-        self.assertEqual(task2.status, 'open')
+        self.assertEqual(task2.status, 'closed')
 
 
 @override_settings(SEND_WELCOME_MAIL=False)

--- a/bluebottle/tasks/models.py
+++ b/bluebottle/tasks/models.py
@@ -106,7 +106,10 @@ class Task(models.Model):
             owner """
         # send "The deadline of your task" - mail
 
-        self.status = 'realized'
+        if (self.status == 'in progress'):
+            self.status = 'realized'
+        else:
+            self.status = 'closed'
         self.save()
 
         data = {


### PR DESCRIPTION
Waiting for confirmation that an open task should be closed when it's deadline is reached.