### PR TITLE
Only check lockdown form on form-encoded requests

### DIFF
--- a/bluebottle/auth/middleware.py
+++ b/bluebottle/auth/middleware.py
@@ -219,7 +219,11 @@ class LockdownMiddleware(BaseLockdownMiddleware):
             if not locked_date:
                 return None
 
-        form_data = request.method == 'POST' and request.POST or {}
+        if request.META.get('CONTENT_TYPE') == 'application/x-www-form-urlencoded' and request.method == 'POST':
+            form_data = request.POST
+        else:
+            form_data = {}
+
         passwords = (request.META['HTTP_X_LOCKDOWN'],)
 
         if self.form is None:


### PR DESCRIPTION
This fixes multipart POSTs when lock-down is enabled.

Touch request.POST before DRF process the requests breaks multipart
messages in DRF. By checking if the content-type is
application/www-formencoded we do not touch request.POST, not exposing
this bug.

BB-7841 #resolve