### PR TITLE
Soft delete taskmembers

### DIFF
--- a/bluebottle/analytics/tests/test_api.py
+++ b/bluebottle/analytics/tests/test_api.py
@@ -35,7 +35,6 @@ class TaskMemberApiAnalyticsTest(BluebottleTestCase):
             'task': task.id,
             'status': 'realized'
         }
-
         self.client.put(task_member_url, task_member_data, token="JWT {0}".format(user.get_jwt_token()))
         args, kwargs = queue_mock.call_args
         self.assertEqual(kwargs['tags']['status'], 'realized')
@@ -46,6 +45,10 @@ class TaskMemberApiAnalyticsTest(BluebottleTestCase):
         task_member = TaskMemberFactory.create(time_spent=10, member=user, task=task, status='applied')
 
         task_member_url = reverse('task_member_detail', kwargs={'pk': task_member.id})
-        self.client.delete(task_member_url, token="JWT {0}".format(user.get_jwt_token()))
+        task_member_data = {
+            'task': task.id,
+            'status': 'withdrew'
+        }
+        self.client.put(task_member_url, task_member_data, token="JWT {0}".format(user.get_jwt_token()))
         args, kwargs = queue_mock.call_args
         self.assertEqual(kwargs['tags']['status'], 'withdrew')

--- a/bluebottle/analytics/tests/test_api.py
+++ b/bluebottle/analytics/tests/test_api.py
@@ -49,4 +49,3 @@ class TaskMemberApiAnalyticsTest(BluebottleTestCase):
         self.client.delete(task_member_url, token="JWT {0}".format(user.get_jwt_token()))
         args, kwargs = queue_mock.call_args
         self.assertEqual(kwargs['tags']['status'], 'withdrew')
-

--- a/bluebottle/analytics/tests/test_api.py
+++ b/bluebottle/analytics/tests/test_api.py
@@ -25,7 +25,7 @@ class TaskMemberApiAnalyticsTest(BluebottleTestCase):
 
         self.init_projects()
 
-    def test_task_status_changes(self, queue_mock):
+    def test_taskmember_status_changes(self, queue_mock):
         user = BlueBottleUserFactory.create()
         task = TaskFactory.create(author=user, people_needed=2, status='realized')
         task_member = TaskMemberFactory.create(time_spent=10, member=user, task=task, status='applied')
@@ -36,7 +36,17 @@ class TaskMemberApiAnalyticsTest(BluebottleTestCase):
             'status': 'realized'
         }
 
-        response = self.client.put(task_member_url, task_member_data,
-                                    token="JWT {0}".format(user.get_jwt_token()))
+        self.client.put(task_member_url, task_member_data, token="JWT {0}".format(user.get_jwt_token()))
         args, kwargs = queue_mock.call_args
         self.assertEqual(kwargs['tags']['status'], 'realized')
+
+    def test_taskmember_delete_status_changes(self, queue_mock):
+        user = BlueBottleUserFactory.create()
+        task = TaskFactory.create(author=user, people_needed=2, status='realized')
+        task_member = TaskMemberFactory.create(time_spent=10, member=user, task=task, status='applied')
+
+        task_member_url = reverse('task_member_detail', kwargs={'pk': task_member.id})
+        self.client.delete(task_member_url, token="JWT {0}".format(user.get_jwt_token()))
+        args, kwargs = queue_mock.call_args
+        self.assertEqual(kwargs['tags']['status'], 'withdrew')
+

--- a/bluebottle/analytics/tests/test_models.py
+++ b/bluebottle/analytics/tests/test_models.py
@@ -225,7 +225,7 @@ class TestTaskMemberAnalytics(BluebottleTestCase):
 
     def test_unchanged_status(self, queue_mock):
         user = BlueBottleUserFactory.create()
-        task_member = TaskMemberFactory.create(member=user)
+        task_member = TaskMemberFactory.create(member=user, status='applied')
         previous_call_count = queue_mock.call_count
 
         # Update record without changing status

--- a/bluebottle/bb_accounts/tests/test_models.py
+++ b/bluebottle/bb_accounts/tests/test_models.py
@@ -190,7 +190,7 @@ class BlueBottleUserTestCase(BluebottleTestCase):
 
         TaskMemberFactory.create(
             member=self.user,
-            status=TaskMember.TaskMemberStatuses.stopped,
+            status=TaskMember.TaskMemberStatuses.withdrew,
             task=task
         )
 

--- a/bluebottle/bb_tasks/tests/__init__.py
+++ b/bluebottle/bb_tasks/tests/__init__.py
@@ -1,2 +1,0 @@
-from .test_api import *
-from .test_mails import *

--- a/bluebottle/bb_tasks/tests/test_api.py
+++ b/bluebottle/bb_tasks/tests/test_api.py
@@ -309,13 +309,13 @@ class TaskApiIntegrationTests(BluebottleTestCase):
         task = TaskFactory.create()
         task_member = TaskMemberFactory.create(member=self.some_user, task=task)
 
-        self.assertEquals(task.members.count(), 1)
+        self.assertEquals(task.people_applied, 1)
 
         response = self.client.delete(
             '{0}{1}'.format(self.task_members_url, task_member.id),
             token=self.some_token)
 
-        self.assertEquals(task.members.count(), 0)
+        self.assertEquals(task.people_applied, 0)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT,
                          response.data)
 

--- a/bluebottle/bb_tasks/tests/test_api.py
+++ b/bluebottle/bb_tasks/tests/test_api.py
@@ -459,11 +459,10 @@ class TestTaskSearchCase(BluebottleTestCase):
                                             timezone.timedelta(days=365),
                                             people_needed=1)
 
-        event_task_5 = TaskFactory.create(status='open',
-                                          type='event',
-                                          deadline=self.now +
-                                          timezone.timedelta(days=365),
-                                          people_needed=1)
+        TaskFactory.create(status='open',
+                           type='event',
+                           deadline=self.now + timezone.timedelta(days=365),
+                           people_needed=1)
 
         search_date = {
             'start': str((self.tomorrow + timezone.timedelta(days=3)).date()),
@@ -548,9 +547,3 @@ class SkillListApiTests(BluebottleTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK,
                          response.data)
         self.assertEquals(len(response.data), 3)
-
-
-
-# TODO: Test edit task
-# TODO: Test change TaskMember edit status
-# TODO: Test File uploads

--- a/bluebottle/bb_tasks/tests/test_api.py
+++ b/bluebottle/bb_tasks/tests/test_api.py
@@ -333,8 +333,7 @@ class TaskApiIntegrationTests(BluebottleTestCase):
             '{0}{1}'.format(self.task_members_url, task_member.id),
             token=self.some_token)
 
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN,
-                         response.data)
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     def test_withdraw_task_member_unauthorized(self):
         task = TaskFactory.create()

--- a/bluebottle/bb_tasks/tests/test_mails.py
+++ b/bluebottle/bb_tasks/tests/test_mails.py
@@ -1,7 +1,6 @@
 from bluebottle.tasks.models import Task, TaskMember
 from bluebottle.test.utils import BluebottleTestCase
 from django.core import mail
-from django.test import TestCase
 
 from bluebottle.test.factory_models.accounts import BlueBottleUserFactory
 from bluebottle.test.factory_models.projects import ProjectFactory
@@ -9,7 +8,9 @@ from bluebottle.test.factory_models.tasks import TaskFactory, TaskMemberFactory
 
 
 class TaskEmailTests(BluebottleTestCase):
-    """ Tests for tasks: sending e-mails on certain status changes. """
+    """
+    Tests for tasks: sending e-mails on certain status changes.
+    """
 
     def setUp(self):
         super(TaskEmailTests, self).setUp()
@@ -43,7 +44,9 @@ class TaskEmailTests(BluebottleTestCase):
         self.task.save()
 
     def test_mail_taskmember_applied_sent(self):
-        """ Test that the e-mails were sent for the task applications """
+        """
+        Test that the e-mails were sent for the task applications.
+        """
         self.assertEqual(len(mail.outbox), 2)
 
         m = mail.outbox.pop(0)
@@ -59,8 +62,9 @@ class TaskEmailTests(BluebottleTestCase):
         self.assertEqual(m.recipients()[0], self.some_project.owner.email)
 
     def test_mail_member_accepted(self):
-        """ Test the sent mail for accepted task members """
-
+        """
+        Test the sent mail for accepted task members.
+        """
         # there should be two mails in the outbox from the application
         self.assertEqual(len(mail.outbox), 2)
         # delete them, they're not relevant for this test

--- a/bluebottle/bb_tasks/tests/test_models.py
+++ b/bluebottle/bb_tasks/tests/test_models.py
@@ -1,8 +1,7 @@
 from django.utils import timezone
 
 from bluebottle.test.utils import BluebottleTestCase
-from bluebottle.test.factory_models.tasks import SkillFactory, TaskFactory, \
-    TaskMemberFactory
+from bluebottle.test.factory_models.tasks import TaskFactory, TaskMemberFactory
 
 
 class TestTaskMemberCase(BluebottleTestCase):
@@ -10,7 +9,9 @@ class TestTaskMemberCase(BluebottleTestCase):
         self.init_projects()
 
     def test_check_number_of_members_needed_no_externals_count(self):
-        """ Test that 'check_number_of_members_needed' returns the right count without externals"""
+        """
+        Test that 'check_number_of_members_needed' returns the right count without externals.
+        """
         task = TaskFactory.create(status='open', people_needed=4)
 
         task_member1 = TaskMemberFactory.create(task=task, status='accepted')
@@ -21,7 +22,9 @@ class TestTaskMemberCase(BluebottleTestCase):
         self.assertEqual(task_member1.task.people_accepted, 2)
 
     def test_check_number_of_members_needed_with_externals_count(self):
-        """ Test that 'check_number_of_members_needed' returns the right count with externals"""
+        """
+        Test that 'check_number_of_members_needed' returns the right count with externals.
+        """
         task = TaskFactory.create(status='open', people_needed=4)
 
         task_member1 = TaskMemberFactory.create(task=task, status='accepted',
@@ -34,8 +37,10 @@ class TestTaskMemberCase(BluebottleTestCase):
         self.assertEqual(task_member1.task.people_accepted, 5)
 
     def test_check_number_of_members_needed_set_in_progress(self):
-        """ Test that the task status changes when enough people are accepted for a task. It shouldn't update 
-            when insufficient people are accepted."""
+        """
+        Test that the task status changes when enough people are accepted
+        for a task. It shouldn't updatewhen insufficient people are accepted.
+        """
         task = TaskFactory.create(status='open', people_needed=4)
 
         task_member1 = TaskMemberFactory.create(task=task, status='accepted',
@@ -57,8 +62,11 @@ class TestTaskCase(BluebottleTestCase):
         self.init_projects()
 
     def test_save_check_status_update_insufficent_accepted_members(self):
-        """ Check that the save method correctly sets the status of the task if not enough task members are
-            accepted for the task and the save method is called """
+        """
+        Check that the save method correctly sets the status of the task if
+        not enough task members are accepted for the task and the
+        save method is called.
+        """
         task = TaskFactory.create(status='open', people_needed=4)
         TaskMemberFactory.create(task=task, status='accepted', externals=1)
         task.save()
@@ -72,11 +80,13 @@ class TestTaskCase(BluebottleTestCase):
         self.assertEqual(task.status, 'open')
 
     def test_save_check_status_update_sufficent_accepted_members(self):
-        """ Check that the save method correctly sets the status of the task if enough task members are 
-            accepted for the task and the save method is called """
+        """
+        Check that the save method correctly sets the status
+        of the task if enough task members are
+        accepted for the task and the save method is called
+        """
         task = TaskFactory.create(status='open', people_accepted=2)
-        TaskMemberFactory.create(task=task, status='accepted',
-                                                externals=1)
+        TaskMemberFactory.create(task=task, status='accepted', externals=1)
         task.save()
 
         self.assertEqual(task.status, 'in progress')

--- a/bluebottle/bb_tasks/tests/test_models.py
+++ b/bluebottle/bb_tasks/tests/test_models.py
@@ -14,11 +14,11 @@ class TestTaskMemberCase(BluebottleTestCase):
         task = TaskFactory.create(status='open', people_needed=4)
 
         task_member1 = TaskMemberFactory.create(task=task, status='accepted')
-        self.assertEqual(task_member1.check_number_of_members_needed(task), 1)
+        self.assertEqual(task_member1.task.people_accepted, 1)
 
         task_member2 = TaskMemberFactory.create(task=task, status='accepted')
-        self.assertEqual(task_member2.check_number_of_members_needed(task), 2)
-        self.assertEqual(task_member1.check_number_of_members_needed(task), 2)
+        self.assertEqual(task_member2.task.people_accepted, 2)
+        self.assertEqual(task_member1.task.people_accepted, 2)
 
     def test_check_number_of_members_needed_with_externals_count(self):
         """ Test that 'check_number_of_members_needed' returns the right count with externals"""
@@ -26,12 +26,12 @@ class TestTaskMemberCase(BluebottleTestCase):
 
         task_member1 = TaskMemberFactory.create(task=task, status='accepted',
                                                 externals=1)
-        self.assertEqual(task_member1.check_number_of_members_needed(task), 2)
+        self.assertEqual(task_member1.task.people_accepted, 2)
 
         task_member2 = TaskMemberFactory.create(task=task, status='accepted',
                                                 externals=2)
-        self.assertEqual(task_member2.check_number_of_members_needed(task), 5)
-        self.assertEqual(task_member1.check_number_of_members_needed(task), 5)
+        self.assertEqual(task_member2.task.people_accepted, 5)
+        self.assertEqual(task_member1.task.people_accepted, 5)
 
     def test_check_number_of_members_needed_set_in_progress(self):
         """ Test that the task status changes when enough people are accepted for a task. It shouldn't update 
@@ -41,15 +41,14 @@ class TestTaskMemberCase(BluebottleTestCase):
         task_member1 = TaskMemberFactory.create(task=task, status='accepted',
                                                 externals=1)
 
-        self.assertEqual(task_member1.check_number_of_members_needed(task), 2)
+        self.assertEqual(task_member1.task.people_accepted, 2)
         # Not enough people yet
         self.assertEqual(task.status, 'open')
 
-        task_member2 = TaskMemberFactory.create(task=task, status='accepted',
-                                                externals=2)
+        task_member2 = TaskMemberFactory.create(task=task, status='accepted', externals=2)
 
-        self.assertEqual(task_member2.check_number_of_members_needed(task), 5)
-        # More than people_needed have applied
+        self.assertEqual(task_member2.task.people_accepted, 5)
+        # More than people_accepted have applied
         self.assertEqual(task.status, 'in progress')
 
 
@@ -58,16 +57,15 @@ class TestTaskCase(BluebottleTestCase):
         self.init_projects()
 
     def test_save_check_status_update_insufficent_accepted_members(self):
-        """ Check that the save method correctly sets the status of the task if not enough task members are 
+        """ Check that the save method correctly sets the status of the task if not enough task members are
             accepted for the task and the save method is called """
         task = TaskFactory.create(status='open', people_needed=4)
-        task_member1 = TaskMemberFactory.create(task=task, status='accepted',
-                                                externals=1)
+        TaskMemberFactory.create(task=task, status='accepted', externals=1)
         task.save()
 
         self.assertEqual(task.status, 'open')
 
-        task_member2 = TaskMemberFactory.create(task=task, status='accepted')
+        TaskMemberFactory.create(task=task, status='accepted')
         task.save()
 
         # Total of 3 out of 4 people. Task status should be open.
@@ -76,8 +74,8 @@ class TestTaskCase(BluebottleTestCase):
     def test_save_check_status_update_sufficent_accepted_members(self):
         """ Check that the save method correctly sets the status of the task if enough task members are 
             accepted for the task and the save method is called """
-        task = TaskFactory.create(status='open', people_needed=2)
-        task_member1 = TaskMemberFactory.create(task=task, status='accepted',
+        task = TaskFactory.create(status='open', people_accepted=2)
+        TaskMemberFactory.create(task=task, status='accepted',
                                                 externals=1)
         task.save()
 

--- a/bluebottle/bb_tasks/views.py
+++ b/bluebottle/bb_tasks/views.py
@@ -209,18 +209,12 @@ class MyTaskMemberList(generics.ListAPIView):
         return queryset.filter(member=self.request.user)
 
 
-class TaskMemberDetail(generics.RetrieveUpdateDestroyAPIView):
+class TaskMemberDetail(generics.RetrieveUpdateAPIView):
     queryset = TaskMember.objects.all()
     serializer_class = BaseTaskMemberSerializer
 
     permission_classes = (TenantConditionalOpenClose,
                           IsMemberOrAuthorOrReadOnly,)
-
-    def delete(self, request, *args, **kwargs):
-        instance = self.get_object()
-        instance.status = 'withdrew'
-        instance.save()
-        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class TaskFileList(generics.ListCreateAPIView):

--- a/bluebottle/bb_tasks/views.py
+++ b/bluebottle/bb_tasks/views.py
@@ -6,7 +6,9 @@ from django.db.models.query_utils import Q
 from django.utils import timezone
 
 from rest_framework import generics, filters, serializers
+from rest_framework import status
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.response import Response
 
 from bluebottle.bluebottle_drf2.pagination import BluebottlePagination
 from bluebottle.bluebottle_drf2.permissions import IsAuthorOrReadOnly
@@ -191,7 +193,7 @@ class TaskMemberList(generics.ListCreateAPIView):
     pagination_class = TaskPagination
     filter_fields = ('task', 'status',)
     permission_classes = (TenantConditionalOpenClose,
-                          IsAuthenticatedOrReadOnly,)
+                          IsAuthenticatedOrReadOnly)
     queryset = TaskMember.objects.all()
 
     def perform_create(self, serializer):
@@ -204,10 +206,7 @@ class MyTaskMemberList(generics.ListAPIView):
 
     def get_queryset(self):
         queryset = super(MyTaskMemberList, self).get_queryset()
-        # valid_statuses = [TaskMember.TaskMemberStatuses.accepted,
-        # TaskMember.TaskMemberStatuses.realized]
-        return queryset.filter(
-            member=self.request.user)  # , status__in=valid_statuses)
+        return queryset.filter(member=self.request.user)
 
 
 class TaskMemberDetail(generics.RetrieveUpdateDestroyAPIView):
@@ -216,6 +215,12 @@ class TaskMemberDetail(generics.RetrieveUpdateDestroyAPIView):
 
     permission_classes = (TenantConditionalOpenClose,
                           IsMemberOrAuthorOrReadOnly,)
+
+    def delete(self, request, *args, **kwargs):
+        instance = self.get_object()
+        instance.status = 'withdrew'
+        instance.save()
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class TaskFileList(generics.ListCreateAPIView):

--- a/bluebottle/tasks/admin.py
+++ b/bluebottle/tasks/admin.py
@@ -1,12 +1,8 @@
-import pytz
-
 from django.contrib import admin
 from django.utils.translation import ugettext_lazy as _
 from django.core.urlresolvers import reverse
-from django.utils import timezone
 
 from bluebottle.tasks.models import TaskMember, TaskFile, Task, Skill
-
 from bluebottle.utils.admin import export_as_csv_action
 
 
@@ -170,7 +166,6 @@ class TaskMemberAdmin(admin.ModelAdmin):
     member_email.admin_order_field = 'member__email'
     member_email.short_description = "Member Email"
 
-
     def lookup_allowed(self, key, value):
         if key in ('task__deadline__year',):
             return True
@@ -179,8 +174,6 @@ class TaskMemberAdmin(admin.ModelAdmin):
 
 
 admin.site.register(TaskMember, TaskMemberAdmin)
-
-from django.utils import translation
 
 
 class SkillAdmin(admin.ModelAdmin):

--- a/bluebottle/tasks/serializers.py
+++ b/bluebottle/tasks/serializers.py
@@ -121,5 +121,3 @@ class TaskPreviewSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Task
-
-

--- a/bluebottle/tasks/serializers.py
+++ b/bluebottle/tasks/serializers.py
@@ -33,7 +33,7 @@ class TaskFileSerializer(serializers.ModelSerializer):
 
 
 class BaseTaskSerializer(serializers.ModelSerializer):
-    members = BaseTaskMemberSerializer(many=True, read_only=True)
+    members = BaseTaskMemberSerializer(many=True, read_only=True, source='members_applied')
     files = TaskFileSerializer(many=True, read_only=True)
     project = serializers.SlugRelatedField(slug_field='slug',
                                            queryset=Project.objects)
@@ -117,7 +117,7 @@ class TaskPreviewSerializer(serializers.ModelSerializer):
     author = UserPreviewSerializer()
     project = ProjectPreviewSerializer()
     skill = serializers.PrimaryKeyRelatedField(queryset=Skill)
-    members = BaseTaskMemberSerializer(many=True, read_only=True)
+    members = BaseTaskMemberSerializer(many=True, read_only=True, source="members_applied")
 
     class Meta:
         model = Task

--- a/bluebottle/tasks/signals.py
+++ b/bluebottle/tasks/signals.py
@@ -20,7 +20,31 @@ def task_post_save(sender, instance, **kwargs):
     except AttributeError:
         pass
 
-@receiver(pre_save, weak=False, sender=TaskMember, dispatch_uid='set-hours-spent-taskmember')
+@receiver(pre_save, weak=False, sender=TaskMember,
+          dispatch_uid='set-hours-spent-taskmember')
 def set_hours_spent_taskmember(sender, instance, **kwargs):
     if instance.status != instance._initial_status and instance.status == TaskMember.TaskMemberStatuses.realized:
         instance.time_spent = instance.task.time_needed
+
+# post save members needed
+@receiver(post_save, sender=TaskMember,
+          dispatch_uid="bluebottle.tasks.TaskMember.post_save")
+def calculate_members_needed(sender, instance, **kwargs):
+    task = instance.task
+    members = TaskMember.objects.filter(
+        task=task,
+        status__in=('accepted', 'realized')
+    )
+    total_externals = 0
+    for member in members:
+        total_externals += member.externals
+
+    members_accepted = members.count() + total_externals
+
+    if task.status == Task.TaskStatuses.open and \
+                    task.people_needed <= members_accepted:
+        task.set_in_progress()
+
+    if task.status == Task.TaskStatuses.in_progress and \
+                    task.people_needed > members_accepted:
+        task.set_open()

--- a/bluebottle/tasks/signals.py
+++ b/bluebottle/tasks/signals.py
@@ -20,11 +20,13 @@ def task_post_save(sender, instance, **kwargs):
     except AttributeError:
         pass
 
+
 @receiver(pre_save, weak=False, sender=TaskMember,
           dispatch_uid='set-hours-spent-taskmember')
 def set_hours_spent_taskmember(sender, instance, **kwargs):
     if instance.status != instance._initial_status and instance.status == TaskMember.TaskMemberStatuses.realized:
         instance.time_spent = instance.task.time_needed
+
 
 # post save members needed
 @receiver(post_save, sender=TaskMember,
@@ -39,12 +41,11 @@ def calculate_members_needed(sender, instance, **kwargs):
     for member in members:
         total_externals += member.externals
 
-    members_accepted = members.count() + total_externals
+    people_accepted = members.count() + total_externals
 
-    if task.status == Task.TaskStatuses.open and \
-                    task.people_needed <= members_accepted:
+    if task.status == Task.TaskStatuses.open and task.people_needed <= people_accepted:
         task.set_in_progress()
 
-    if task.status == Task.TaskStatuses.in_progress and \
-                    task.people_needed > members_accepted:
+    if task.status == Task.TaskStatuses.in_progress and task.people_needed > people_accepted:
         task.set_open()
+    task.save()

--- a/bluebottle/tasks/tests/test_api.py
+++ b/bluebottle/tasks/tests/test_api.py
@@ -253,7 +253,7 @@ class TaskApiTestcase(BluebottleTestCase):
         response = self.client.get(task_url)
         self.assertEqual(response.data['status'], 'in progress')
 
-       # When a applied member is realized task status should stay 'in progress''
+        # When a applied member is realized task status should stay 'in progress''
         response = self.client.patch(task_member_url,
                                    {'status': 'realized'},
                                    HTTP_AUTHORIZATION=self.some_token)

--- a/bluebottle/tasks/tests/test_api.py
+++ b/bluebottle/tasks/tests/test_api.py
@@ -54,9 +54,9 @@ class TaskApiTestcase(BluebottleTestCase):
                                    HTTP_AUTHORIZATION=self.some_token)
         self.assertEqual(response.data['results'][0]['task_count'], 1)
 
-        task_member = TaskMemberFactory.create(member=self.another_user,
-                                               task=self.task1,
-                                               status='accepted')
+        TaskMemberFactory.create(member=self.another_user,
+                                 task=self.task1,
+                                 status='accepted')
 
         # The task has one task member and two people needed, still one task open
         response = self.client.get(self.previews_url,
@@ -99,7 +99,7 @@ class TaskApiTestcase(BluebottleTestCase):
         self.task1.status = Task.TaskStatuses.open
         self.task1.save()
 
-        task2 = TaskFactory.create(
+        TaskFactory.create(
             status=Task.TaskStatuses.open,
             author=self.some_project.owner,
             project=self.some_project,
@@ -204,16 +204,16 @@ class TaskApiTestcase(BluebottleTestCase):
         task_member_id = response.data['id']
         task_member_url = reverse('task_member_detail', kwargs={'pk': task_member_id})
         response = self.client.patch(task_member_url,
-                                   {'status': 'accepted'},
-                                   HTTP_AUTHORIZATION=self.some_token)
+                                     {'status': 'accepted'},
+                                     HTTP_AUTHORIZATION=self.some_token)
         self.assertEqual(response.status_code, HTTP_200_OK)
         response = self.client.get(task_url)
         self.assertEqual(response.data['status'], 'in progress')
 
         # When the accepted member is rejected task status should change back to 'open'
         response = self.client.patch(task_member_url,
-                                   {'status': 'rejected'},
-                                   HTTP_AUTHORIZATION=self.some_token)
+                                     {'status': 'rejected'},
+                                     HTTP_AUTHORIZATION=self.some_token)
         self.assertEqual(response.status_code, HTTP_200_OK)
         response = self.client.get(task_url)
         self.assertEqual(response.data['status'], 'open')
@@ -226,8 +226,8 @@ class TaskApiTestcase(BluebottleTestCase):
         task_member_id = response.data['id']
         task_member_url = reverse('task_member_detail', kwargs={'pk': task_member_id})
         response = self.client.patch(task_member_url,
-                                   {'status': 'accepted'},
-                                   HTTP_AUTHORIZATION=self.some_token)
+                                     {'status': 'accepted'},
+                                     HTTP_AUTHORIZATION=self.some_token)
         self.assertEqual(response.status_code, HTTP_200_OK)
         response = self.client.get(task_url)
         self.assertEqual(response.data['status'], 'in progress')
@@ -247,16 +247,16 @@ class TaskApiTestcase(BluebottleTestCase):
         task_member_id = response.data['id']
         task_member_url = reverse('task_member_detail', kwargs={'pk': task_member_id})
         response = self.client.patch(task_member_url,
-                                   {'status': 'accepted'},
-                                   HTTP_AUTHORIZATION=self.some_token)
+                                     {'status': 'accepted'},
+                                     HTTP_AUTHORIZATION=self.some_token)
         self.assertEqual(response.status_code, HTTP_200_OK)
         response = self.client.get(task_url)
         self.assertEqual(response.data['status'], 'in progress')
 
         # When a applied member is realized task status should stay 'in progress''
         response = self.client.patch(task_member_url,
-                                   {'status': 'realized'},
-                                   HTTP_AUTHORIZATION=self.some_token)
+                                     {'status': 'realized'},
+                                     HTTP_AUTHORIZATION=self.some_token)
         self.assertEqual(response.status_code, HTTP_200_OK)
         response = self.client.get(task_url)
         self.assertEqual(response.data['status'], 'in progress')
@@ -282,4 +282,3 @@ class TaskApiTestcase(BluebottleTestCase):
                                     HTTP_AUTHORIZATION=self.some_token)
         self.assertEqual(response.status_code, HTTP_201_CREATED)
         self.assertEqual(response.data['deadline'], '2016-08-09T23:59:59.999999+02:00')
-

--- a/bluebottle/tasks/tests/test_api.py
+++ b/bluebottle/tasks/tests/test_api.py
@@ -233,9 +233,13 @@ class TaskApiTestcase(BluebottleTestCase):
         self.assertEqual(response.data['status'], 'in progress')
 
         # When a applied member is withdraws task status should change to 'open'
-        response = self.client.delete(task_member_url,
-                                      HTTP_AUTHORIZATION=self.some_token)
-        self.assertEqual(response.status_code, HTTP_204_NO_CONTENT)
+        response = self.client.put(task_member_url,
+                                   {
+                                       'status': 'withdrew',
+                                       'task': task.id
+                                   },
+                                   HTTP_AUTHORIZATION=self.some_token)
+        self.assertEqual(response.status_code, HTTP_200_OK)
         response = self.client.get(task_url)
         self.assertEqual(response.data['status'], 'open')
 

--- a/bluebottle/tasks/tests/test_mails.py
+++ b/bluebottle/tasks/tests/test_mails.py
@@ -125,4 +125,3 @@ class TestTaskStatusMail(TaskMailTestBase):
         self.assertEquals(len(mail.outbox), 1)
 
         self.assertTrue('set to closed' in mail.outbox[0].subject)
-

--- a/bluebottle/tasks/tests/test_models.py
+++ b/bluebottle/tasks/tests/test_models.py
@@ -1,8 +1,5 @@
-from django.utils import timezone
-
 from bluebottle.test.utils import BluebottleTestCase
-from bluebottle.test.factory_models.tasks import SkillFactory, TaskFactory, \
-    TaskMemberFactory
+from bluebottle.test.factory_models.tasks import TaskFactory, TaskMemberFactory
 from bluebottle.tasks.models import TaskStatusLog, TaskMemberStatusLog
 
 
@@ -32,4 +29,3 @@ class TestTaskMemberStatusLog(BluebottleTestCase):
         self.assertEqual(TaskStatusLog.objects.count(), 1)
         self.assertEqual(log.status, 'applied')
         self.assertEqual(log.task_member_id, task_member.id)
-

--- a/bluebottle/tasks/tests/test_unit.py
+++ b/bluebottle/tasks/tests/test_unit.py
@@ -1,15 +1,11 @@
 import datetime
 
-from django.core import mail
 from django.utils import timezone
-from django.test.utils import override_settings
 
 from bluebottle.bb_projects.models import ProjectPhase
 from bluebottle.tasks.models import Task
-
-from bluebottle.test.factory_models.tasks import TaskFactory, TaskMemberFactory
+from bluebottle.test.factory_models.tasks import TaskFactory
 from bluebottle.test.factory_models.projects import ProjectFactory
-from bluebottle.test.factory_models.surveys import SurveyFactory
 from bluebottle.test.utils import BluebottleTestCase
 
 # import taskmail in order to properly register mail handlers. Without it tests mail fail
@@ -35,7 +31,7 @@ class TestDeadline(TaskUnitTestBase):
     def setUp(self):
         super(TestDeadline, self).setUp()
 
-        self.task.deadline = deadline=timezone.now() - datetime.timedelta(days=1)
+        self.task.deadline = timezone.now() - datetime.timedelta(days=1)
         self.task.save()
 
     def test_deadline_realised(self):


### PR DESCRIPTION
* Don't remove taskmember records if they withdraw
* Move taskmember count to a signal
* Add/adjust tests
* PEP8 tasks/bb_tasks