### PR TITLE
Handle accented titles in project / task list

### DIFF
--- a/bluebottle/tasks/admin.py
+++ b/bluebottle/tasks/admin.py
@@ -124,7 +124,7 @@ class TaskAdminInline(admin.TabularInline):
         url = reverse('admin:{0}_{1}_change'.format(
             object._meta.app_label, object._meta.model_name),
             args=[object.id])
-        return "<a href='{0}'>{1}</a>".format(str(url), obj.title)
+        return "<a href='{0}'>{1}</a>".format(str(url), obj.title.encode("utf8"))
 
     task_admin_link.allow_tags = True
 


### PR DESCRIPTION
Task admin link breaks if title has an accented character