### PR TITLE
Only show payout_status fields if the user has the correct permissions.

### DIFF
--- a/bluebottle/projects/admin.py
+++ b/bluebottle/projects/admin.py
@@ -271,7 +271,7 @@ class ProjectAdmin(AdminImageMixin, ImprovedModelForm):
         if Location.objects.count():
             filters += [LocationGroupFilter, LocationFilter]
         else:
-            filters += ['country__subregion__region', ('country', admin.RelatedOnlyFieldListFilter),]
+            filters += ['country__subregion__region', ('country', admin.RelatedOnlyFieldListFilter), ]
         return filters
 
     def get_list_display(self, request):

--- a/bluebottle/projects/admin.py
+++ b/bluebottle/projects/admin.py
@@ -234,10 +234,10 @@ class ProjectAdmin(AdminImageMixin, ImprovedModelForm):
                ProjectPhaseLogInline)
 
     def get_readonly_fields(self, request, obj=None):
-        fields = ('vote_count',
+        fields = ['vote_count',
                   'amount_donated', 'amount_needed',
-                  'popularity'
-                  )
+                  'popularity', 'payout_status']
+
         return fields
 
     def get_urls(self):
@@ -251,7 +251,7 @@ class ProjectAdmin(AdminImageMixin, ImprovedModelForm):
 
     def approve_payout(self, request, pk=None):
         project = Project.objects.get(pk=pk)
-        if project.payout_status == 'needs_approval':
+        if request.user.has_perm('projects.approve_payout') and project.payout_status == 'needs_approval':
             project.payout_status = 'approved'
             project.save()
         project_url = reverse('admin:projects_project_change', args=(project.id,))
@@ -261,20 +261,26 @@ class ProjectAdmin(AdminImageMixin, ImprovedModelForm):
     list_filter = ('country__subregion__region',)
 
     def get_list_filter(self, request):
-        filters = ('status', 'payout_status', 'is_campaign', ProjectThemeFilter,
-                   'project_type', ('deadline', DateRangeFilter))
+        filters = ['status', 'is_campaign', ProjectThemeFilter,
+                   'project_type', ('deadline', DateRangeFilter)]
+
+        if request.user.has_perm('projects.approve_payout'):
+            filters.insert(1, 'payout_status')
 
         # Only show Location column if there are any
         if Location.objects.count():
-            filters += (LocationGroupFilter, LocationFilter)
+            filters += [LocationGroupFilter, LocationFilter]
         else:
-            filters += ('country__subregion__region', ('country', admin.RelatedOnlyFieldListFilter),)
+            filters += ['country__subregion__region', ('country', admin.RelatedOnlyFieldListFilter),]
         return filters
 
     def get_list_display(self, request):
-        fields = ('get_title_display', 'get_owner_display', 'created',
-                  'status', 'payout_status',
-                  'deadline', 'donated_percentage')
+        fields = ['get_title_display', 'get_owner_display', 'created',
+                  'status', 'deadline', 'donated_percentage']
+
+        if request.user.has_perm('projects.approve_payout'):
+            fields.insert(4, 'payout_status')
+
         # Only show Location column if there are any
         if Location.objects.count():
             fields += ('location',)
@@ -319,37 +325,42 @@ class ProjectAdmin(AdminImageMixin, ImprovedModelForm):
         actions = super(ProjectAdmin, self).get_actions(request)
         return OrderedDict(reversed(actions.items()))
 
-    fieldsets = (
-        (_('Main'), {'fields': ('owner', 'organization',
-                                'status', 'payout_status',
-                                'title', 'slug', 'project_type',
-                                'is_campaign', 'celebrate_results')}),
+    def get_fieldsets(self, request, obj=None):
+        main = {'fields': ['owner', 'organization',
+                           'status', 'title', 'slug', 'project_type',
+                           'is_campaign', 'celebrate_results']}
 
-        (_('Story'), {'fields': ('pitch', 'story', 'reach')}),
+        if request.user.has_perm('projects.approve_payout'):
+            main['fields'].insert(3, 'payout_status')
 
-        (_('Details'), {'fields': ('language', 'theme', 'categories', 'image',
-                                   'video_url', 'country',
-                                   'latitude', 'longitude',
-                                   'location', 'place')}),
+        return (
+            (_('Main'), main),
 
-        (_('Goal'), {'fields': ('amount_asked', 'amount_extra',
-                                'amount_donated', 'amount_needed',
-                                'currencies',
-                                'popularity', 'vote_count')}),
+            (_('Story'), {'fields': ('pitch', 'story', 'reach')}),
 
-        (_('Dates'), {'fields': ('voting_deadline', 'deadline',
-                                 'date_submitted', 'campaign_started',
-                                 'campaign_ended', 'campaign_funded')}),
+            (_('Details'), {'fields': ('language', 'theme', 'categories', 'image',
+                                       'video_url', 'country',
+                                       'latitude', 'longitude',
+                                       'location', 'place')}),
 
-        (_('Bank details'), {'fields': ('account_holder_name',
-                                        'account_holder_address',
-                                        'account_holder_postal_code',
-                                        'account_holder_city',
-                                        'account_holder_country',
-                                        'account_number',
-                                        'account_bic',
-                                        'account_bank_country')})
-    )
+            (_('Goal'), {'fields': ('amount_asked', 'amount_extra',
+                                    'amount_donated', 'amount_needed',
+                                    'currencies',
+                                    'popularity', 'vote_count')}),
+
+            (_('Dates'), {'fields': ('voting_deadline', 'deadline',
+                                     'date_submitted', 'campaign_started',
+                                     'campaign_ended', 'campaign_funded')}),
+
+            (_('Bank details'), {'fields': ('account_holder_name',
+                                            'account_holder_address',
+                                            'account_holder_postal_code',
+                                            'account_holder_city',
+                                            'account_holder_country',
+                                            'account_number',
+                                            'account_bic',
+                                            'account_bank_country')})
+        )
 
     def vote_count(self, obj):
         return obj.vote_set.count()

--- a/bluebottle/projects/models.py
+++ b/bluebottle/projects/models.py
@@ -594,6 +594,7 @@ class Project(BaseProject, PreviousStatusMixin):
         return tweet
 
     class Meta(BaseProject.Meta):
+        permissions = (('approve_payout', 'Can approve payouts for projects'), )
         ordering = ['title']
 
     class Analytics:

--- a/bluebottle/projects/templates/admin/projects/project/change_form.html
+++ b/bluebottle/projects/templates/admin/projects/project/change_form.html
@@ -3,7 +3,7 @@
 
 {% block object-tools-items %}
     <li>
-        {% if original.payout_status == 'needs_approval' %}
+        {% if perms.projects.approve_payout and original.payout_status == 'needs_approval' %}
             <a href="{% url 'admin:projects_project_approve_payout' object_id %}" style="background-color: darkgreen">
                 {% trans  "Approve payout" %}
             </a>

--- a/bluebottle/projects/tests/test_admin.py
+++ b/bluebottle/projects/tests/test_admin.py
@@ -80,7 +80,7 @@ class TestProjectAdmin(BluebottleTestCase):
 
         project = ProjectFactory.create(payout_status='needs_approval')
 
-        response = self.project_admin.approve_payout(request, project.id)
+        self.project_admin.approve_payout(request, project.id)
         self.assertEqual(
             Project.objects.get(id=project.id).payout_status, 'approved'
         )
@@ -91,7 +91,7 @@ class TestProjectAdmin(BluebottleTestCase):
 
         project = ProjectFactory.create(payout_status='needs_approval')
 
-        response = self.project_admin.approve_payout(request, project.id)
+        self.project_admin.approve_payout(request, project.id)
         self.assertEqual(
             Project.objects.get(id=project.id).payout_status, 'needs_approval'
         )
@@ -102,10 +102,7 @@ class TestProjectAdmin(BluebottleTestCase):
 
         project = ProjectFactory.create(payout_status='done')
 
-        response = self.project_admin.approve_payout(request, project.id)
+        self.project_admin.approve_payout(request, project.id)
         self.assertEqual(
             Project.objects.get(id=project.id).payout_status, 'done'
         )
-
-
-

--- a/bluebottle/projects/tests/test_admin.py
+++ b/bluebottle/projects/tests/test_admin.py
@@ -1,0 +1,111 @@
+from django.contrib.admin.sites import AdminSite
+
+from bluebottle.projects.admin import ProjectAdmin
+from bluebottle.projects.models import Project
+from bluebottle.test.factory_models.projects import ProjectFactory
+from bluebottle.test.utils import BluebottleTestCase
+
+
+class MockRequest:
+    pass
+
+
+class MockUser:
+    def __init__(self, perms=None):
+        self.perms = perms or []
+
+    def has_perm(self, perm):
+        return perm in self.perms
+
+
+class TestProjectAdmin(BluebottleTestCase):
+    def setUp(self):
+        super(TestProjectAdmin, self).setUp()
+        self.site = AdminSite()
+
+        self.init_projects()
+        self.project_admin = ProjectAdmin(Project, self.site)
+
+    def test_fieldsets(self):
+        request = MockRequest()
+        request.user = MockUser(['projects.approve_payout'])
+
+        self.assertTrue(
+            'payout_status' in self.project_admin.get_fieldsets(request)[0][1]['fields']
+        )
+
+    def test_fieldsets_no_permissions(self):
+        request = MockRequest()
+        request.user = MockUser()
+
+        self.assertTrue(
+            'payout_status' not in self.project_admin.get_fieldsets(request)
+        )
+
+    def test_list_filter(self):
+        request = MockRequest()
+        request.user = MockUser(['projects.approve_payout'])
+
+        self.assertTrue(
+            'payout_status' in self.project_admin.get_list_filter(request)
+        )
+
+    def test_list_filter_no_permissions(self):
+        request = MockRequest()
+        request.user = MockUser()
+
+        self.assertTrue(
+            'payout_status' not in self.project_admin.get_list_filter(request)
+        )
+
+    def test_list_display(self):
+        request = MockRequest()
+        request.user = MockUser(['projects.approve_payout'])
+
+        self.assertTrue(
+            'payout_status' in self.project_admin.get_list_display(request)
+        )
+
+    def test_list_display_no_permissions(self):
+        request = MockRequest()
+        request.user = MockUser()
+
+        self.assertTrue(
+            'payout_status' not in self.project_admin.get_list_display(request)
+        )
+
+    def test_mark_payout_as_approved(self):
+        request = MockRequest()
+        request.user = MockUser(['projects.approve_payout'])
+
+        project = ProjectFactory.create(payout_status='needs_approval')
+
+        response = self.project_admin.approve_payout(request, project.id)
+        self.assertEqual(
+            Project.objects.get(id=project.id).payout_status, 'approved'
+        )
+
+    def test_mark_payout_as_approved_no_permissions(self):
+        request = MockRequest()
+        request.user = MockUser()
+
+        project = ProjectFactory.create(payout_status='needs_approval')
+
+        response = self.project_admin.approve_payout(request, project.id)
+        self.assertEqual(
+            Project.objects.get(id=project.id).payout_status, 'needs_approval'
+        )
+
+    def test_mark_payout_as_approved_wrong_status(self):
+        request = MockRequest()
+        request.user = MockUser(['projects.approve_payout'])
+
+        project = ProjectFactory.create(payout_status='done')
+
+        response = self.project_admin.approve_payout(request, project.id)
+        self.assertEqual(
+            Project.objects.get(id=project.id).payout_status, 'done'
+        )
+
+
+


### PR DESCRIPTION
- Only show in list_fields and list_displays if the user has permission
- Make payout status readonly
- Do permission check in approve_payout

BB-9050 #resolve