### PR TITLE
Remind the task owner to confirm the participants.

### DIFF
--- a/bluebottle/tasks/models.py
+++ b/bluebottle/tasks/models.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.db import models, connection
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
@@ -12,6 +14,7 @@ from bluebottle.clients import properties
 from bluebottle.clients.utils import tenant_url
 from bluebottle.utils.managers import UpdateSignalsQuerySet
 from bluebottle.utils.utils import PreviousStatusMixin
+from bluebottle.utils.email_backend import send_mail
 
 
 GROUP_PERMS = {
@@ -185,11 +188,11 @@ class Task(models.Model, PreviousStatusMixin):
             #  And schedule two more mails (in  3 and 6 days)
             send_task_realized_mail.apply_async(
                 [self, 'task_status_realized_reminder', second_subject, connection.tenant],
-                eta=now() + timedelta(days=3)
+                eta=timezone.now() + timedelta(days=3)
             )
             send_task_realized_mail.apply_async(
                 [self, 'task_status_realized_second_reminder', third_subject, connection.tenant],
-                eta=now() + timedelta(days=6)
+                eta=timezone.now() + timedelta(days=6)
             )
 
         if oldstate in ("in progress", "open") and newstate == "closed":
@@ -393,6 +396,6 @@ class TaskMemberStatusLog(models.Model):
         }
 
 
-from .taskmail import *  # noqa
+from .taskmail import send_task_realized_mail  # noqa
 from .taskwallmails import *  # noqa
 from .signals import *  # noqa

--- a/bluebottle/tasks/taskmail.py
+++ b/bluebottle/tasks/taskmail.py
@@ -1,12 +1,17 @@
+from datetime import timedelta
+from celery import shared_task
+
 from django.dispatch import receiver
+from django.db import connection
 from django.db.models.signals import post_save, pre_delete
-from django.utils.translation import ugettext as _
 from django.utils import translation
+from django.utils.translation import ugettext as _
+from django.utils.timezone import now
 from django.utils.safestring import mark_safe
 
 from tenant_extras.utils import TenantLanguage
 
-from bluebottle.clients.utils import tenant_url
+from bluebottle.clients.utils import tenant_url, LocalTenant
 from bluebottle.tasks.models import TaskMember
 from bluebottle.surveys.models import Survey
 from bluebottle.utils.email_backend import send_mail
@@ -148,6 +153,28 @@ class TaskMemberMailAdapter:
     def send_mail(self):
         if self.mail_sender:
             self.mail_sender.send()
+
+
+@shared_task
+def send_task_realized_mail(task, template, subject, tenant):
+    """ Send an email to the task owner with the request to confirm
+    the task participants.
+    """
+    connection.set_tenant(tenant)
+
+    with LocalTenant(tenant, clear_tenant=True):
+        if len(task.members.filter(status=TaskMember.TaskMemberStatuses.realized)):
+            # There is already a confirmed task member: Do not bother the owner
+            return
+
+        send_mail(
+            template_name='tasks/mails/{}.mail'.format(template),
+            subject=subject,
+            title=task.title,
+            to=task.author,
+            site=tenant_url(),
+            link='/go/tasks/{0}'.format(task.id)
+        )
 
 
 @receiver(post_save, weak=False, sender=TaskMember)

--- a/bluebottle/tasks/taskmail.py
+++ b/bluebottle/tasks/taskmail.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from celery import shared_task
 
 from django.dispatch import receiver
@@ -6,7 +5,6 @@ from django.db import connection
 from django.db.models.signals import post_save, pre_delete
 from django.utils import translation
 from django.utils.translation import ugettext as _
-from django.utils.timezone import now
 from django.utils.safestring import mark_safe
 
 from tenant_extras.utils import TenantLanguage

--- a/bluebottle/tasks/templates/tasks/mails/task_status_realized_reminder.mail.html
+++ b/bluebottle/tasks/templates/tasks/mails/task_status_realized_reminder.mail.html
@@ -6,7 +6,8 @@
 
         Hello {{ receiver_name }}
         <br><br>
-        Hopefully your task was a great success! Make sure that all participants are confirmed so we can show the results of your tasks.
+        Hopefully your task "{{ title }}" was a great success! 
+        Make sure that all participants are marked as confirmed so we can show the results of your project.
     {% endblocktrans %}
 {% endblock %}
 

--- a/bluebottle/tasks/templates/tasks/mails/task_status_realized_reminder.mail.html
+++ b/bluebottle/tasks/templates/tasks/mails/task_status_realized_reminder.mail.html
@@ -1,0 +1,16 @@
+{% extends "base.mail.html" %}
+{% load i18n %}
+
+{% block content %}
+    {% blocktrans with receiver_name=to.short_name %}
+
+        Hello {{ receiver_name }}
+        <br><br>
+        Hopefully your task was a great success! Make sure that all participants are confirmed so we can show the results of your tasks.
+    {% endblocktrans %}
+{% endblock %}
+
+{% block action %}
+    <a href="{{ site }}{{ link }}"
+       class="action-email">{% trans 'Confirm participants' context 'email' %}</a>
+{% endblock %}`

--- a/bluebottle/tasks/templates/tasks/mails/task_status_realized_reminder.mail.txt
+++ b/bluebottle/tasks/templates/tasks/mails/task_status_realized_reminder.mail.txt
@@ -6,7 +6,8 @@
 
 Hello {{receiver_name}}
 
-Hopefully your task was a great success! Make sure that all participants are confirmed so we can show the results of your tasks.
+Hopefully your task "{{ title }}" was a great success! 
+Make sure that all participants are marked as confirmed so we can show the results of your project.
 {% endblocktrans %}
 {% endblock %}
 

--- a/bluebottle/tasks/templates/tasks/mails/task_status_realized_reminder.mail.txt
+++ b/bluebottle/tasks/templates/tasks/mails/task_status_realized_reminder.mail.txt
@@ -1,0 +1,15 @@
+{% extends "base.mail.txt" %}
+{% load i18n %}
+
+{% block content %}
+{% blocktrans with receiver_name=to.short_name  %}
+
+Hello {{receiver_name}}
+
+Hopefully your task was a great success! Make sure that all participants are confirmed so we can show the results of your tasks.
+{% endblocktrans %}
+{% endblock %}
+
+{% block action %}
+{% trans 'Confirm participants' context 'email' %} {{ site }}{{ link }}
+{% endblock %}`

--- a/bluebottle/tasks/templates/tasks/mails/task_status_realized_second_reminder.mail.html
+++ b/bluebottle/tasks/templates/tasks/mails/task_status_realized_second_reminder.mail.html
@@ -6,7 +6,7 @@
 
         Hello {{ receiver_name }}
         <br><br>
-        In case it slipped your mind. Please confirm the participants of your task so we can show the results of your tasks.
+        In case it slipped your mind. Please confirm the participants who executed "{{ title }}" so we can show the results of your project.
     {% endblocktrans %}
 {% endblock %}
 

--- a/bluebottle/tasks/templates/tasks/mails/task_status_realized_second_reminder.mail.html
+++ b/bluebottle/tasks/templates/tasks/mails/task_status_realized_second_reminder.mail.html
@@ -1,0 +1,16 @@
+{% extends "base.mail.html" %}
+{% load i18n %}
+
+{% block content %}
+    {% blocktrans with receiver_name=to.short_name %}
+
+        Hello {{ receiver_name }}
+        <br><br>
+        In case it slipped your mind. Please confirm the participants of your task so we can show the results of your tasks.
+    {% endblocktrans %}
+{% endblock %}
+
+{% block action %}
+    <a href="{{ site }}{{ link }}"
+       class="action-email">{% trans 'Confirm participants' context 'email' %}</a>
+{% endblock %}`

--- a/bluebottle/tasks/templates/tasks/mails/task_status_realized_second_reminder.mail.txt
+++ b/bluebottle/tasks/templates/tasks/mails/task_status_realized_second_reminder.mail.txt
@@ -6,7 +6,7 @@
 
 Hello {{receiver_name}}
 
-In case it slipped your mind. Please confirm the participants of your task so we can show the results of your tasks.
+In case it slipped your mind. Please confirm the participants who executed "{{ title }}" so we can show the results of your project.
 {% endblocktrans %}
 {% endblock %}
 

--- a/bluebottle/tasks/templates/tasks/mails/task_status_realized_second_reminder.mail.txt
+++ b/bluebottle/tasks/templates/tasks/mails/task_status_realized_second_reminder.mail.txt
@@ -1,0 +1,15 @@
+{% extends "base.mail.txt" %}
+{% load i18n %}
+
+{% block content %}
+{% blocktrans with receiver_name=to.short_name  %}
+
+Hello {{receiver_name}}
+
+In case it slipped your mind. Please confirm the participants of your task so we can show the results of your tasks.
+{% endblocktrans %}
+{% endblock %}
+
+{% block action %}
+{% trans 'Confirm participants' context 'email' %} {{ site }}{{ link }}
+{% endblock %}`

--- a/bluebottle/tasks/tests/test_mails.py
+++ b/bluebottle/tasks/tests/test_mails.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from mock import patch
 
-from django.db import models, connection
+from django.db import connection
 from django.core import mail
 from django.test.utils import override_settings
 from django.utils.timezone import now

--- a/bluebottle/tasks/tests/test_unit.py
+++ b/bluebottle/tasks/tests/test_unit.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django.utils import timezone
+from django.test.utils import override_settings
 
 from bluebottle.bb_projects.models import ProjectPhase
 from bluebottle.tasks.models import Task
@@ -47,6 +48,7 @@ class TestDeadline(TaskUnitTestBase):
         self.assertEqual(self.task.status, Task.TaskStatuses.closed)
 
 
+@override_settings(CELERY_RESULT_BACKEND=None)
 class TestTaskRealised(TaskUnitTestBase):
     """
     Test the status of a project when a task is realised


### PR DESCRIPTION
Besides sending an email to the task owner when the task is realized,
also schedule 2 more tasks (in 3 and 6 days), that remind the owner to
confirm the participants.

Only send the email when there are no realized members (also holds for
the email send immediately).

BB-9105 #resolve