### PR TITLE
Add the recipient to the email template context.

### DIFF
--- a/bluebottle/tasks/tests/test_mails.py
+++ b/bluebottle/tasks/tests/test_mails.py
@@ -126,6 +126,7 @@ class TestTaskStatusMail(TaskMailTestBase):
         # There should be one email send immediately
         self.assertEquals(len(mail.outbox), 1)
         self.assertTrue('set to realized' in mail.outbox[0].subject)
+        self.assertTrue('Hello {}'.format(self.task.author.short_name) in mail.outbox[0].body)
 
         # And there should be 2 scheduled
 
@@ -200,6 +201,7 @@ class TestTaskStatusMail(TaskMailTestBase):
         self.assertEquals(len(mail.outbox), 1)
         email = mail.outbox[0]
         self.assertEqual(email.subject, 'test subject')
+        self.assertTrue('Hello {}'.format(self.task.author.short_name) in mail.outbox[0].body)
         self.assertTrue(
             'Hopefully your task "{}" was a great success'.format(self.task.title) in email.body
         )
@@ -221,6 +223,7 @@ class TestTaskStatusMail(TaskMailTestBase):
         self.assertTrue(
             'In case it slipped your mind' in email.body
         )
+        self.assertTrue('Hello {}'.format(self.task.author.short_name) in mail.outbox[0].body)
         self.assertTrue(
             'https://testserver/go/tasks/{}'.format(self.task.pk) in email.body
         )

--- a/bluebottle/utils/email_backend.py
+++ b/bluebottle/utils/email_backend.py
@@ -110,6 +110,7 @@ def create_message(template_name=None, to=None, subject=None, cc=None, bcc=None,
 
     with TenantLanguage(language):
         c = ClientContext(kwargs)
+        c['to'] = to  # Add the recipient to the context
         text_content = get_template(
             '{0}.txt'.format(template_name)).render(c)
         html_content = get_template(


### PR DESCRIPTION
Fixes recipient name being empty in (among others) task emails.

BB-9338 #resolve