### PR TITLE
Speed up result pages

### DIFF
--- a/bluebottle/cms/serializers.py
+++ b/bluebottle/cms/serializers.py
@@ -1,6 +1,8 @@
 from django.db import connection
 from django.db.models import Sum
 
+from memoize import memoize
+
 from bluebottle.bluebottle_drf2.serializers import ImageSerializer, SorlImageField
 from bluebottle.members.models import Member
 from bluebottle.members.serializers import UserPreviewSerializer
@@ -113,7 +115,7 @@ class ProjectImagesContentSerializer(serializers.ModelSerializer):
         projects = Project.objects.filter(
             campaign_ended__gte=self.context['start_date'],
             campaign_ended__lte=self.context['end_date'],
-            status__slug__in=['done-complete', 'done-incomplete']).order_by('?')
+            status__slug__in=['done-complete', 'done-incomplete']).order_by('?')[:8]
 
         return ProjectImageSerializer(projects, many=True).to_representation(projects)
 
@@ -126,6 +128,7 @@ class ProjectImagesContentSerializer(serializers.ModelSerializer):
 class ProjectsMapContentSerializer(serializers.ModelSerializer):
     projects = serializers.SerializerMethodField()
 
+    @memoize(timeout=60 * 60)
     def get_projects(self, obj):
         projects = Project.objects.filter(
             campaign_ended__gte=self.context['start_date'],
@@ -137,6 +140,11 @@ class ProjectsMapContentSerializer(serializers.ModelSerializer):
         )
 
         return ProjectTinyPreviewSerializer(projects, many=True).to_representation(projects)
+
+    def __repr__(self):
+        start = self.context['start_date'].strftime('%s') if self.context['start_date'] else 'none'
+        end = self.context['end_date'].strftime('%s') if self.context['end_date'] else 'none'
+        return 'MapsContent({},{})'.format(start, end)
 
     class Meta:
         model = ProjectImagesContent
@@ -232,21 +240,23 @@ class SupporterTotalContentSerializer(serializers.ModelSerializer):
 class BlockSerializer(serializers.Serializer):
     def to_representation(self, obj):
         if isinstance(obj, StatsContent):
-            return StatsContentSerializer(obj, context=self.context).to_representation(obj)
+            serializer = StatsContentSerializer
         if isinstance(obj, QuotesContent):
-            return QuotesContentSerializer(obj, context=self.context).to_representation(obj)
+            serializer = QuotesContentSerializer
         if isinstance(obj, ProjectImagesContent):
-            return ProjectImagesContentSerializer(obj, context=self.context).to_representation(obj)
+            serializer = ProjectImagesContentSerializer
         if isinstance(obj, SurveyContent):
-            return SurveyContentSerializer(obj, context=self.context).to_representation(obj)
+            serializer = SurveyContentSerializer
         if isinstance(obj, ProjectsContent):
-            return ProjectsContentSerializer(obj, context=self.context).to_representation(obj)
+            serializer = ProjectsContentSerializer
         if isinstance(obj, ShareResultsContent):
-            return ShareResultsContentSerializer(obj, context=self.context).to_representation(obj)
+            serializer = ShareResultsContentSerializer
         if isinstance(obj, ProjectsMapContent):
-            return ProjectsMapContentSerializer(obj, context=self.context).to_representation(obj)
+            serializer = ProjectsMapContentSerializer
         if isinstance(obj, SupporterTotalContent):
-            return SupporterTotalContentSerializer(obj, context=self.context).to_representation(obj)
+            serializer = SupporterTotalContentSerializer
+
+        return serializer(obj, context=self.context).to_representation(obj)
 
 
 def watermark():

--- a/bluebottle/statistics/statistics.py
+++ b/bluebottle/statistics/statistics.py
@@ -23,7 +23,7 @@ class Statistics(object):
         self.end = end
 
     @property
-    @memoize(timeout=300)
+    @memoize(timeout=60 * 60)
     def people_involved(self):
         """
         The (unique) total number of people that donated, fundraised, campaigned, or was a
@@ -100,13 +100,13 @@ class Statistics(object):
         return Q(**filter_args)
 
     @property
-    @memoize(timeout=300)
+    @memoize(timeout=60 * 60)
     def tasks_realized(self):
         """ Total number of realized tasks """
         return len(Task.objects.filter(self.date_filter('deadline'), status='realized'))
 
     @property
-    @memoize(timeout=300)
+    @memoize(timeout=60 * 60)
     def projects_realized(self):
         """ Total number of realized (complete and incomplete) projects """
         return len(Project.objects.filter(
@@ -114,7 +114,7 @@ class Statistics(object):
         ))
 
     @property
-    @memoize(timeout=300)
+    @memoize(timeout=60 * 60)
     def projects_online(self):
         """ Total number of projects that have been in campaign mode"""
         return len(
@@ -122,7 +122,7 @@ class Statistics(object):
         )
 
     @property
-    @memoize(timeout=300)
+    @memoize(timeout=60 * 60)
     def donated_total(self):
         """ Total amount donated to all projects"""
         donations = Donation.objects.filter(
@@ -139,12 +139,12 @@ class Statistics(object):
         return donated
 
     @property
-    @memoize(timeout=300)
+    @memoize(timeout=60 * 60)
     def votes_cast(self):
         return len(Vote.objects.filter(self.date_filter()))
 
     @property
-    @memoize(timeout=300)
+    @memoize(timeout=60 * 60)
     def time_spent(self):
         """ Total amount of time spent on realized tasks """
         return TaskMember.objects.filter(
@@ -153,7 +153,7 @@ class Statistics(object):
         ).aggregate(time_spent=Sum('time_spent'))['time_spent']
 
     @property
-    @memoize(timeout=300)
+    @memoize(timeout=60 * 60)
     def amount_matched(self):
         """ Total amount matched on realized (done and incomplete) projects """
         totals = Project.objects.filter(


### PR DESCRIPTION
* Do not return all project images (we do not show them anyway)
* Cache maps result
* Extend caching from 5 minutes to an hour

BB-9263 #resolve