### PR TITLE
Use only payout statuses that make sense for users.

### DIFF
--- a/bluebottle/projects/models.py
+++ b/bluebottle/projects/models.py
@@ -237,14 +237,11 @@ class Project(BaseProject, PreviousStatusMixin):
 
     PAYOUT_STATUS_CHOICES = (
         (StatusDefinition.NEEDS_APPROVAL, _('Needs approval')),
-        (StatusDefinition.APPROVED, _('Approved')),
-        (StatusDefinition.CREATED, _('Created')),
         (StatusDefinition.SCHEDULED, _('Scheduled')),
         (StatusDefinition.RE_SCHEDULED, _('Re-scheduled')),
         (StatusDefinition.IN_PROGRESS, _('In progress')),
-        (StatusDefinition.PARTIAL, _('Partial')),
+        (StatusDefinition.PARTIAL, _('Partially paid')),
         (StatusDefinition.SUCCESS, _('Success')),
-        (StatusDefinition.CONFIRMED, _('Confirmed')),
         (StatusDefinition.FAILED, _('Failed'))
     )
 


### PR DESCRIPTION
Dorado is updated to map payout settings to correct project settings.

BB-9194 #resolve