### PR TITLE
Set the payout status to created BEFORE we call out to dorado. This way

### DIFF
--- a/bluebottle/payouts_dorado/adapters.py
+++ b/bluebottle/payouts_dorado/adapters.py
@@ -31,11 +31,11 @@ class DoradoPayoutAdapter(object):
         }
 
         try:
-            response = requests.post(self.settings['url'], data)
-            response.raise_for_status()
-
             self.project.payout_status = 'created'
             self.project.save()
+
+            response = requests.post(self.settings['url'], data)
+            response.raise_for_status()
         except requests.HTTPError:
             try:
                 raise PayoutValidationError(json.loads(response.content))


### PR DESCRIPTION
we do not override that status that dorado set.

BB-9471 #resolve