### PR TITLE
Do not mark payments as created.

### DIFF
--- a/bluebottle/payouts_dorado/adapters.py
+++ b/bluebottle/payouts_dorado/adapters.py
@@ -31,9 +31,6 @@ class DoradoPayoutAdapter(object):
         }
 
         try:
-            self.project.payout_status = 'created'
-            self.project.save()
-
             response = requests.post(self.settings['url'], data)
             response.raise_for_status()
         except requests.HTTPError:

--- a/bluebottle/projects/tests/test_admin.py
+++ b/bluebottle/projects/tests/test_admin.py
@@ -211,7 +211,12 @@ class TestProjectAdmin(BluebottleTestCase):
             'status' in self.project_admin.get_readonly_fields(request, obj=project)
         )
 
-        with mock.patch('requests.post', return_value=self.mock_response):
+        def side_effect(*args, **kwargs):
+            project.payout_status = 'approved'
+            project.save()
+            return self.mock_response
+
+        with mock.patch('requests.post', side_effect=side_effect):
             self.project_admin.approve_payout(request, project.id)
 
         project = Project.objects.get(id=project.id)


### PR DESCRIPTION
This is not a a valid choice in the model. If something goes wrong
during the payout creation, this status will not show, and it will not
be possible to change the status.

Under normal conditions, the status would only be set to "created"
while waiting for the payout app do do the status callback. So in that
situation, it also is not useful,

BB-9613 #resolve