### PR TITLE
add time_spent to task member serializer

### DIFF
--- a/bluebottle/bb_tasks/tests/test_api.py
+++ b/bluebottle/bb_tasks/tests/test_api.py
@@ -210,12 +210,12 @@ class TaskApiIntegrationTests(BluebottleTestCase):
         """
         Ensure we can filter task list by status
         """
-        self.task1 = TaskFactory.create(
+        TaskFactory.create(
             status=Task.TaskStatuses.in_progress,
             author=self.some_project.owner,
             project=self.some_project,
         )
-        self.task2 = TaskFactory.create(
+        TaskFactory.create(
             status=Task.TaskStatuses.open,
             author=self.another_project.owner,
             project=self.another_project,
@@ -247,13 +247,13 @@ class TaskApiIntegrationTests(BluebottleTestCase):
         self.another_project.save()
 
         # create tasks for projects
-        self.task1 = TaskFactory.create(
+        task1 = TaskFactory.create(
             status=Task.TaskStatuses.in_progress,
             author=self.some_project.owner,
             project=self.some_project,
             deadline=timezone.datetime(2010, 05, 05, tzinfo=timezone.get_current_timezone())
         )
-        self.task2 = TaskFactory.create(
+        TaskFactory.create(
             status=Task.TaskStatuses.open,
             author=self.another_project.owner,
             project=self.another_project,
@@ -284,20 +284,20 @@ class TaskApiIntegrationTests(BluebottleTestCase):
                          response.data)
         self.assertEqual(response.data['count'], 0)
 
-        skill = self.task1.skill
+        skill = task1.skill
         response = self.client.get(api_url, {'skill': skill.id},
                                    token=self.some_token)
         self.assertEqual(response.status_code, status.HTTP_200_OK,
                          response.data)
         self.assertEqual(response.data['count'], 1)
-        self.assertEqual(response.data['results'][0]['id'], self.task1.id)
+        self.assertEqual(response.data['results'][0]['id'], task1.id)
 
         response = self.client.get(api_url, {'before': '2011-01-01'},
                                    token=self.some_token)
         self.assertEqual(response.status_code, status.HTTP_200_OK,
                          response.data)
         self.assertEqual(response.data['count'], 1)
-        self.assertEqual(response.data['results'][0]['id'], self.task1.id)
+        self.assertEqual(response.data['results'][0]['id'], task1.id)
 
         response = self.client.get(api_url, {'after': '2011-01-01'},
                                    token=self.some_token)

--- a/bluebottle/bb_tasks/tests/test_api.py
+++ b/bluebottle/bb_tasks/tests/test_api.py
@@ -363,11 +363,22 @@ class TaskApiIntegrationTests(BluebottleTestCase):
                                    token=self.some_token)
 
         # Fields as defined in the serializer
-        serializer_fields = (
-            'id', 'members', 'files', 'project', 'skill', 'author', 'status',
-            'description', 'location', 'deadline', 'time_needed', 'title',
-            'people_needed'
-        )
+        serializer_fields = ('id', 'members', 'files', 'project', 'skill', 'author', 'status', 'description',
+                             'location', 'deadline', 'time_needed', 'title', 'people_needed')
+
+        for field in serializer_fields:
+            self.assertTrue(field in response.data)
+
+    def test_get_correct_base_task_member_fields(self):
+        """ Test that the fields defined in the BaseTaskMember serializer are returned in the response """
+
+        task = TaskFactory.create()
+        task_member = TaskMemberFactory.create(member=self.another_user, task=task)
+
+        response = self.client.get('{0}{1}'.format(self.task_members_url, task_member.id), token=self.some_token)
+
+        # Fields as defined in the serializer
+        serializer_fields = ('id', 'member', 'status', 'created', 'motivation', 'task', 'externals', 'time_spent')
 
         for field in serializer_fields:
             self.assertTrue(field in response.data)

--- a/bluebottle/bb_tasks/tests/test_api.py
+++ b/bluebottle/bb_tasks/tests/test_api.py
@@ -354,6 +354,25 @@ class TaskApiIntegrationTests(BluebottleTestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN,
                          response.data)
 
+    def test_task_member_set_time_spent(self):
+        task = TaskFactory.create(status=Task.TaskStatuses.open,
+                                  project=self.some_project,
+                                  author=self.some_project.owner)
+        task_member = TaskMemberFactory.create(member=self.some_user, task=task)
+
+        # Only task owner can set the time spent
+        response1 = self.client.put('{0}{1}'.format(self.task_members_url, task_member.id),
+                                    {'time_spent': 42, 'task': task.id},
+                                    token=self.some_token)
+
+        self.assertEqual(response1.status_code, status.HTTP_200_OK, response1.data)
+
+        response2 = self.client.put('{0}{1}'.format(self.task_members_url, task_member.id),
+                                    {'time_spent': 5, 'task': task.id},
+                                    token=self.another_token)
+
+        self.assertEqual(response2.status_code, status.HTTP_403_FORBIDDEN, response2.data)
+
     def test_get_correct_base_task_fields(self):
         """ Test that the fields defined in the BaseTask serializer are returned in the response """
 

--- a/bluebottle/tasks/serializers.py
+++ b/bluebottle/tasks/serializers.py
@@ -21,7 +21,7 @@ class BaseTaskMemberSerializer(serializers.ModelSerializer):
     class Meta:
         model = TaskMember
         fields = ('id', 'member', 'status', 'created', 'motivation', 'task',
-                  'externals')
+                  'externals', 'time_spent')
 
 
 class TaskFileSerializer(serializers.ModelSerializer):
@@ -76,9 +76,6 @@ class MyTaskPreviewSerializer(serializers.ModelSerializer):
 class MyTaskMemberSerializer(BaseTaskMemberSerializer):
     task = MyTaskPreviewSerializer()
     member = serializers.PrimaryKeyRelatedField(queryset=Member.objects)
-
-    class Meta(BaseTaskMemberSerializer.Meta):
-        fields = BaseTaskMemberSerializer.Meta.fields + ('time_spent',)
 
 
 class MyTasksSerializer(BaseTaskSerializer):


### PR DESCRIPTION
- [x] Add `task_member.time_spent` to API reponse
- [x] Task Member CANNOT update his/her own time_spent
- [x] Project owner CANNOT update time_spent
- [x] Task author CAN update time_spent