### PR TITLE
remove extra space before start param

### DIFF
--- a/bluebottle/analytics/tasks.py
+++ b/bluebottle/analytics/tasks.py
@@ -44,5 +44,5 @@ def generate_engagement_metrics():
     today = datetime.utcnow().date()
     yesterday = today - timedelta(days=1)
     logger.info("Generating Engagement Metrics: start date: {} end date: {}".format(yesterday, today))
-    call_command('export_engagement_metrics', ' --start', yesterday.strftime('%Y-%m-%d'),
+    call_command('export_engagement_metrics', '--start', yesterday.strftime('%Y-%m-%d'),
                  '--end', today.strftime('%Y-%m-%d'), '--export-to', 'influxdb')


### PR DESCRIPTION
Fixes the error below found in **/var/log/celery/worker.log**

> [2017-05-04 00:15:00,149: ERROR/MainProcess] Task bluebottle.analytics.tasks.generate_engagement_metrics[e1f002f5-a680-4615-b8f4-de6ef653a803] raised unexpected: CommandError(u'Error: argument --start is required',)
Traceback (most recent call last):
  File "/var/www/reef-prod/api/env/local/lib/python2.7/site-packages/celery/app/trace.py", line 240, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/var/www/reef-prod/api/env/local/lib/python2.7/site-packages/celery/app/trace.py", line 438, in __protected_call__
    return self.run(*args, **kwargs)
  File "/var/www/reef-prod/api/releases/20170502-1842-69237962c7fe21ba6ffe5260a5d1e7d849fe4fff/bluebottle/analytics/tasks.py", line 48, in generate_engagement_metrics
    '--end', today.strftime('%Y-%m-%d'), '--export-to', 'influxdb')
  File "/var/www/reef-prod/api/env/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 123, in call_command
    defaults = parser.parse_args(args=[force_text(a) for a in args])
  File "/var/www/reef-prod/api/env/local/lib/python2.7/site-packages/django/core/management/base.py", line 58, in parse_args
    return super(CommandParser, self).parse_args(args, namespace)
  File "/usr/lib/python2.7/argparse.py", line 1688, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/usr/lib/python2.7/argparse.py", line 1723, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/usr/lib/python2.7/argparse.py", line 1947, in _parse_known_args
    self.error(_('argument %s is required') % name)
  File "/var/www/reef-prod/api/env/local/lib/python2.7/site-packages/django/core/management/base.py", line 64, in error
    raise CommandError("Error: %s" % message)
CommandError: Error: argument --start is required
