### PR TITLE
Do not escape title. This should be escaped in the fronten'

### DIFF
--- a/bluebottle/projects/serializers.py
+++ b/bluebottle/projects/serializers.py
@@ -75,7 +75,6 @@ class ProjectDocumentSerializer(serializers.ModelSerializer):
 class ProjectSerializer(serializers.ModelSerializer):
     id = serializers.CharField(source='slug', read_only=True)
     owner = UserProfileSerializer()
-    title = SafeField()
     story = SafeField()
     image = ImageSerializer(required=False)
     task_count = serializers.IntegerField()

--- a/bluebottle/projects/tests/test_api.py
+++ b/bluebottle/projects/tests/test_api.py
@@ -631,48 +631,6 @@ class ProjectStoryXssTest(BluebottleTestCase):
         self.init_projects()
         self.some_user = BlueBottleUserFactory.create()
 
-    def test_unsafe_title(self):
-        title = '''
-        <p onmouseover=\"alert('Persistent_XSS');\"></p>
-        <br size="&{alert('Injected')}">
-        <script>alert('Injected!');</script>
-        '''
-
-        project = ProjectFactory.create(title=title,
-                                        slug="testproject",
-                                        story="testproject",
-                                        owner=self.some_user,
-                                        status=ProjectPhase.objects.get(
-                                            slug='campaign'))
-
-        response = self.client.get(reverse('project_detail',
-                                           args=[project.slug]))
-        escaped_title = '''
-        <p></p>
-        <br>
-        &lt;script&gt;alert(\'Injected!\');&lt;/script&gt;
-        '''
-        self.assertEqual(response.data['title'], escaped_title)
-
-    def test_safe_title(self):
-        title = '''
-            <p>test</p>
-            <blockquote>test</blockquote>
-            <pre>test</pre>
-            <h1>test</h1>
-            <br>
-        '''
-        project = ProjectFactory.create(title=title,
-                                        slug="testproject",
-                                        story="testproject",
-                                        owner=self.some_user,
-                                        status=ProjectPhase.objects.get(
-                                            slug='campaign'))
-
-        response = self.client.get(reverse('project_detail',
-                                           args=[project.slug]))
-        self.assertEqual(response.data['title'], title)
-
     def test_unsafe_story(self):
         story = '''
         <p onmouseover=\"alert('Persistent_XSS');\"></p>


### PR DESCRIPTION
For some reason did not escape the title in the frontend, but did it in the backend.

That is not the standard way of doing things, and cause issues with place were we expect unescaped strings.