### PR TITLE
Fix migration.

### DIFF
--- a/bluebottle/tasks/migrations/0021_auto_20170503_1435.py
+++ b/bluebottle/tasks/migrations/0021_auto_20170503_1435.py
@@ -19,11 +19,19 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunSQL(
+            'SET CONSTRAINTS ALL IMMEDIATE',
+            reverse_sql=migrations.RunSQL.noop
+        ),
         migrations.RunPython(set_deadline_to_apply),
         migrations.AlterField(
             model_name='task',
             name='deadline_to_apply',
             field=models.DateTimeField(default=None, help_text='Deadline to apply', verbose_name='deadline_to_apply'),
             preserve_default=False,
+        ),
+        migrations.RunSQL(
+            migrations.RunSQL.noop,
+            reverse_sql='SET CONSTRAINTS ALL IMMEDIATE'
         ),
     ]


### PR DESCRIPTION
The migration failed on the server with:

django.db.utils.OperationalError: cannot ALTER TABLE "tasks_task"
because it has pending trigger events

See
http://stackoverflow.com/questions/28429933/django-migrations-using-runpython-to-commit-changes
on why this fixes that issue.