### PR TITLE
Add default exposed settings for tasks / cv upload

### DIFF
--- a/bluebottle/clients/tests/test_api.py
+++ b/bluebottle/clients/tests/test_api.py
@@ -17,6 +17,11 @@ class ClientSettingsTestCase(BluebottleTestCase):
         super(ClientSettingsTestCase, self).setUp()
         self.settings_url = reverse('settings')
 
+    @override_settings(PARENT={'child': True}, EXPOSED_TENANT_PROPERTIES=['parent.child'])
+    def test_nested_exposed_properties(self):
+        response = self.client.get(self.settings_url)
+        self.assertEqual(response.data['parent']['child'], True)
+
     @override_settings(CLOSED_SITE=False, TOP_SECRET="*****", EXPOSED_TENANT_PROPERTIES=['closed_site'])
     def test_settings_show(self):
         # Check that exposed property is in settings api, and other settings are not shown

--- a/bluebottle/settings/base.py
+++ b/bluebottle/settings/base.py
@@ -571,8 +571,10 @@ EXPOSED_TENANT_PROPERTIES = ['closed_site', 'mixpanel', 'analytics', 'maps_api_k
                              'bb_apps', 'donation_amounts', 'facebook_sharing_reviewed',
                              'project_create_flow', 'project_create_types', 'project_contact_types',
                              'closed_site', 'partner_login', 'share_options', 'sso_url',
-                             'project_suggestions', 'readOnlyFields', 'search_options',
-                             'task_accepting', 'task_show_accepting', 'task_plus_one']
+                             'project_suggestions', 'readOnlyFields',
+                             'search_options.filter_types', 'search_options.filters',
+                             'tasks.accepting', 'tasks.show_accepting', 'tasks.plus_one',
+                             'tasks.cv_upload']
 
 DEFAULT_FILE_STORAGE = 'bluebottle.utils.storage.TenantFileSystemStorage'
 
@@ -803,6 +805,10 @@ SEARCH_OPTIONS = {
     'filter_types': ['funding', 'volunteering'],
     'filters': ['project.status', 'project.location', 'project.theme']
 }
-TASK_ACCEPTING = 'manual'
-TASK_PLUS_ONE = False
-TASK_SHOW_ACCEPTING = False
+
+TASKS = {
+    'cv_upload': 'allowed',  # allowed, required or disabled
+    'accepting': 'manual',
+    'plus_one': False,
+    'show_accepting': False
+}


### PR DESCRIPTION
And refactor exposed settings so nested settings can be more explicitly defined. We should have to be explicit so we don't accidentally expose settings. 
BB-9496 #resolve

