### PR TITLE
Add tests that specifically test partner permissions

### DIFF
--- a/bluebottle/bb_tasks/views.py
+++ b/bluebottle/bb_tasks/views.py
@@ -17,7 +17,8 @@ from bluebottle.tasks.serializers import (BaseTaskSerializer,
                                           BaseTaskMemberSerializer, TaskFileSerializer,
                                           TaskPreviewSerializer, MyTaskMemberSerializer,
                                           SkillSerializer, MyTasksSerializer)
-from bluebottle.utils.permissions import TenantConditionalOpenClose
+
+from bluebottle.utils.permissions import TenantConditionalOpenClose, ResourcePermissions
 from bluebottle.utils.views import PrivateFileView
 
 from .permissions import IsMemberOrAuthorOrReadOnly
@@ -159,6 +160,13 @@ class TaskList(BaseTaskList, FilterQSParams):
             qs = qs.order_by('-created')
         elif ordering == 'deadline':
             qs = qs.order_by('deadline')
+
+        permissions = ResourcePermissions().get_required_permissions(
+            self.request.method, qs.model
+        )
+        if not self.request.user.has_perms(permissions):
+            qs = qs.filter(author=self.request.user)
+
 
         return qs
 

--- a/bluebottle/members/serializers.py
+++ b/bluebottle/members/serializers.py
@@ -124,6 +124,17 @@ class UserProfileSerializer(serializers.ModelSerializer):
     time_spent = serializers.ReadOnlyField()
     tasks_performed = serializers.ReadOnlyField()
 
+    sensitive_fields = ['picture', 'avatar', 'location', 'about_me', 'skill_ids']
+
+    def __init__(self, *args, **kwargs):
+        super(UserProfileSerializer, self).__init__(*args, **kwargs)
+
+        if ('request' in self.context and
+                not self.context['request'].user.has_perm('api_read_full_profile')
+        ):
+            for field in self.sensitive_fields:
+                self.fields.pop(field)
+
     class Meta:
         model = BB_USER_MODEL
         fields = ('id', 'url', 'full_name', 'short_name', 'picture',

--- a/bluebottle/projects/models.py
+++ b/bluebottle/projects/models.py
@@ -703,10 +703,11 @@ class Project(BaseProject, PreviousStatusMixin):
     class Meta(BaseProject.Meta):
         permissions = (
             ('approve_payout', 'Can approve payouts for projects'),
+            ('api_read_own_project', 'Can read own projects'),
             ('api_read_project', 'Can view projects through the API'),
             ('api_add_project', 'Can add projects through the API'),
-            ('api_change_project', 'Can change projects through the API'),
-            ('api_delete_project', 'Can delete projects through the API'),
+            ('api_change_own_project', 'Can change own projects through the API'),
+            ('api_delete_own_project', 'Can delete own projects through the API'),
             ('api_read_projectdocument', 'Can view project documents through the API'),
             ('api_add_projectdocument', 'Can add project documents through the API'),
             ('api_change_projectdocument', 'Can change project documents through the API'),

--- a/bluebottle/projects/permissions.py
+++ b/bluebottle/projects/permissions.py
@@ -1,7 +1,7 @@
 from rest_framework import permissions
 
 from bluebottle.utils.utils import get_class
-from bluebottle.utils.permissions import BasePermission, RelatedResourceOwnerPermission
+from bluebottle.utils.permissions import RelatedResourceOwnerPermission
 
 
 class RelatedProjectOwnerPermission(RelatedResourceOwnerPermission):
@@ -18,17 +18,14 @@ class RelatedProjectOwnerPermission(RelatedResourceOwnerPermission):
         return parent
 
 
-class IsEditableOrReadOnly(BasePermission):
+class IsEditableOrReadOnly():
     def has_object_permission(self, request, view, obj):
-        return self.has_object_method_permission(request.method, None, view, obj)
-
-    def has_object_method_permission(self, method, user, view, obj=None):
         # Read permissions are allowed to any request, so we'll always allow
         # GET, HEAD or OPTIONS requests.
-        if method in permissions.SAFE_METHODS:
+        if request.method in permissions.SAFE_METHODS:
             return True
 
         return obj.status.editable
 
-    def has_method_permission(self, method, user, view):
+    def has_permission(self, request, view):
         return True

--- a/bluebottle/rewards/models.py
+++ b/bluebottle/rewards/models.py
@@ -65,7 +65,10 @@ class Reward(models.Model):
         verbose_name_plural = _("Gifts")
         permissions = (
             ('api_read_reward', 'Can view reward through the API'),
+            ('api_read_own_reward', 'Can view own reward through the API'),
             ('api_add_reward', 'Can add reward through the API'),
             ('api_change_reward', 'Can change reward through the API'),
+            ('api_change_own_reward', 'Can change own reward through the API'),
             ('api_delete_reward', 'Can delete reward through the API'),
+            ('api_delete_own_reward', 'Can delete own reward through the API'),
         )

--- a/bluebottle/rewards/permissions.py
+++ b/bluebottle/rewards/permissions.py
@@ -5,7 +5,6 @@ class NoDonationsOrReadOnly(permissions.BasePermission):
     """
     If a reward has no donations it should be editable/deletable
     """
-
     def has_object_permission(self, request, view, obj):
         if request.method in permissions.SAFE_METHODS:
             return True

--- a/bluebottle/tasks/serializers.py
+++ b/bluebottle/tasks/serializers.py
@@ -56,6 +56,13 @@ class BaseTaskSerializer(serializers.ModelSerializer):
                                            max_digits=5,
                                            decimal_places=2)
 
+
+    def __init__(self, *args, **kwargs):
+        super(BaseTaskSerializer, self).__init__(*args, **kwargs)
+
+        if not self.context['request'].user.has_perm('api_read_taskmember'):
+            self.fields.pop('members')
+
     def validate(self, data):
         if self.instance and data.get('deadline') and self.instance.deadline.date() == data['deadline'].date():
             # The date has not changed: Do not validate

--- a/bluebottle/utils/serializers.py
+++ b/bluebottle/utils/serializers.py
@@ -158,12 +158,9 @@ class URLField(serializers.URLField):
 
 
 class FakePermissionRequest(object):
-    def __init__(self, request, method):
-        self.request = request
+    def __init__(self, user, method):
+        self.request = user
         self.method = method
-
-    def __getattr__(self, attr):
-        return getattr(self.request, attr)
 
 
 class PermissionField(serializers.Field):
@@ -203,9 +200,11 @@ class PermissionField(serializers.Field):
         for method in view.allowed_methods:
             permissions[method] = all(
                 perm.has_object_permission(
-                    FakePermissionRequest(self.context['request'], method),
+                    FakePermissionRequest(
+                        self.context['request'].user, method
+                    ),
                     view,
-                    value # FIXME, Make sure that we pass in the correct object, not the parent
+                    value  # FIXME, Make sure that we pass in the correct object, not the parent
                 ) for perm in view.get_permissions()
             )
 

--- a/bluebottle/utils/views.py
+++ b/bluebottle/utils/views.py
@@ -10,6 +10,8 @@ from django.views.generic.base import View
 
 from rest_framework import generics
 from rest_framework import views, response
+from rest_condition import Or
+
 from sorl.thumbnail.shortcuts import get_thumbnail
 from taggit.models import Tag
 from tenant_extras.utils import TenantLanguage
@@ -17,7 +19,7 @@ from tenant_extras.utils import TenantLanguage
 from bluebottle.clients import properties
 from bluebottle.projects.models import Project
 from bluebottle.utils.email_backend import send_mail
-from bluebottle.utils.permissions import ResourcePermissions
+from bluebottle.utils.permissions import ResourcePermissions, ResourceOwnerPermission
 
 from .models import Language
 from .serializers import ShareSerializer, LanguageSerializer
@@ -244,24 +246,38 @@ class PrivateFileView(PermissionedView):
 
 
 class ListAPIView(ViewPermissionsMixin, generics.ListAPIView):
-    base_permission_classes = (ResourcePermissions,)
+    base_permission_classes = (
+        Or(ResourcePermissions, ResourceOwnerPermission),
+    )
 
 
 class UpdateAPIView(ViewPermissionsMixin, generics.UpdateAPIView):
-    base_permission_classes = (ResourcePermissions,)
+    base_permission_classes = (
+        Or(ResourcePermissions, ResourceOwnerPermission),
+    )
 
 
 class RetrieveAPIView(ViewPermissionsMixin, generics.RetrieveAPIView):
-    base_permission_classes = (ResourcePermissions,)
+    base_permission_classes = (
+        Or(ResourcePermissions, ResourceOwnerPermission),
+    )
 
 
 class ListCreateAPIView(ViewPermissionsMixin, generics.ListCreateAPIView):
-    base_permission_classes = (ResourcePermissions,)
+    base_permission_classes = (
+        Or(ResourcePermissions, ResourceOwnerPermission),
+    )
 
 
 class RetrieveUpdateAPIView(ViewPermissionsMixin, generics.RetrieveUpdateAPIView):
-    base_permission_classes = (ResourcePermissions,)
+    base_permission_classes = (
+        Or(ResourcePermissions, ResourceOwnerPermission),
+    )
 
 
 class RetrieveUpdateDestroyAPIView(ViewPermissionsMixin, generics.RetrieveUpdateDestroyAPIView):
-    base_permission_classes = (ResourcePermissions,)
+    base_permission_classes = (
+        Or(ResourcePermissions, ResourceOwnerPermission),
+    )
+
+

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ install_requires = [
     'raven==6.1.0',
     'regex==2017.05.26',
     'requests==2.17.3',
+    'rest-condition==1.0.3',
     'sorl-thumbnail==12.3-github',
     'sorl-watermark==1.0.0',
     'South==1.0.2',


### PR DESCRIPTION
* Remove the has_method* permission methods. Instead use the normal
  has_permission methods and pass in a fake request object
* Add api_<action>_own_<model_name> permissions. This makes it possible
  to only allow a user to see his own resources
* Set default permission class to
  Or(ResourcePermission, ResoueceOwnerPermission) (requires additional
  rest-conditions package)
* Filter task, project and reward list view on owner if user does not
  have full permissions
* Do not expose "members" if user misses task member permissions (this
  probably needs to check permission classes instead of checking
  permissions directly.