### PR TITLE
Updates for user creation in the BO

### DIFF
--- a/bluebottle/bb_accounts/templates/bb_accounts/activation_email_no_password.html
+++ b/bluebottle/bb_accounts/templates/bb_accounts/activation_email_no_password.html
@@ -1,0 +1,17 @@
+{% extends "base.mail.html" %}
+{% load i18n %}
+
+{% block content %}
+{% blocktrans %}
+<h1>Welcome {{ first_name }}</h1>
+<p class="lead">You're officially part of {{ site_name }}</p>
+{% endblocktrans %}
+{% blocktrans %}
+<p>To get started please set your password.</p>
+{% endblocktrans %}
+{% endblock %}
+
+{% block action %}
+    <a href="{{ site }}/go/passwordreset/{{ uid }}-{{ token }}/"
+       class="action-email">{% trans 'Set password' context 'email' %}</a>
+{% endblock %}

--- a/bluebottle/bb_accounts/templates/bb_accounts/activation_email_no_password.txt
+++ b/bluebottle/bb_accounts/templates/bb_accounts/activation_email_no_password.txt
@@ -1,0 +1,16 @@
+{% extends "base.mail.txt" %}
+{% load i18n %}
+
+{% block content %}
+{% blocktrans %}
+Welcome {{ first_name }}
+You're officially part of {{ site_name }}
+{% endblocktrans %}
+{% blocktrans %}
+To get started please set your password.
+{% endblocktrans %}
+{% endblock %}
+
+{% block action %}
+{% trans 'Set password' context 'email' %}: {{ site }}/go/passwordreset/{{ uid }}-{{ token }}/
+{% endblock %}

--- a/bluebottle/bb_accounts/tests/test_api.py
+++ b/bluebottle/bb_accounts/tests/test_api.py
@@ -252,6 +252,7 @@ class UserApiIntegrationTest(BluebottleTestCase):
                          {u'GET': True, u'OPTIONS': True})
         self.client.logout()
 
+    @override_settings(SEND_WELCOME_MAIL=True)
     def test_user_create(self):
         """
         Test creating a user with the api and activating the new user.
@@ -268,6 +269,10 @@ class UserApiIntegrationTest(BluebottleTestCase):
         response = self.client.post(self.user_create_api_url, {'password': new_user_password})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.data)
         self.assertEqual(response.data['email'][0], 'This field is required.')
+
+        welcome_email = mail.outbox[0]
+        self.assertEqual(welcome_email.to, [new_user_email])
+        self.assertTrue('Let\'s get started' in welcome_email.body)
 
     def test_duplicate_user_create(self):
         """

--- a/bluebottle/bb_accounts/utils.py
+++ b/bluebottle/bb_accounts/utils.py
@@ -16,7 +16,7 @@ def send_welcome_mail(user=None):
         with TenantLanguage(user.primary_language):
             subject = _("Welcome to %(site_name)s") % {'site_name': tenant_name()}
 
-    c = {
+    data = {
         'email': user.email,
         'site': tenant_url(),
         'site_name': tenant_name(),
@@ -27,20 +27,21 @@ def send_welcome_mail(user=None):
         'LANGUAGE_CODE': user.primary_language,
     }
 
-    # If there is no password set then use the welcome + password set template
-    if not user.password:
+    # If there is no password and no remote_id (SSO) then use the
+    # welcome + password template, and then set a random password
+    if not user.password and not user.remote_id:
         send_mail(
             template_name='bb_accounts/activation_email_no_password',
             subject=subject,
             to=user,
-            **c
+            **data
         )
     else:
         send_mail(
             template_name='bb_accounts/activation_email',
             subject=subject,
             to=user,
-            **c
+            **data
         )
 
 
@@ -49,7 +50,7 @@ def valid_email(email=None):
     if not email:
         return False
     pattern = r"[^@]+@[^@]+\.[^@]+"
-    p = re.compile(pattern)
-    if p.match(email):
+    pat = re.compile(pattern)
+    if pat.match(email):
         return True
     return False

--- a/bluebottle/members/admin.py
+++ b/bluebottle/members/admin.py
@@ -21,22 +21,16 @@ BB_USER_MODEL = get_user_model()
 
 class MemberCreationForm(forms.ModelForm):
     """
-    A form that creates a member, with no privileges,
-    from the given email and password.
+    A form that creates a member, with no privileges, from the given email.
     """
     error_messages = {
         'duplicate_email': _("A user with that email already exists."),
-        'password_mismatch': _("The two password fields didn't match."),
     }
     email = forms.EmailField(label=_("email address"), max_length=254,
                              help_text=_(
                                  "Required. 254 characters or fewer. A valid email address."))
-    password1 = forms.CharField(label=_("Password"),
-                                widget=forms.PasswordInput)
-    password2 = forms.CharField(label=_("Password confirmation"),
-                                widget=forms.PasswordInput,
-                                help_text=_(
-                                    "Enter the same password as above, for verification."))
+    first_name = forms.CharField(label=_("first name"), max_length=100)
+    last_name = forms.CharField(label=_("last name"), max_length=100,)
 
     class Meta:
         model = BB_USER_MODEL
@@ -51,17 +45,9 @@ class MemberCreationForm(forms.ModelForm):
             return email
         raise forms.ValidationError(self.error_messages['duplicate_email'])
 
-    def clean_password2(self):
-        password1 = self.cleaned_data.get("password1")
-        password2 = self.cleaned_data.get("password2")
-        if password1 and password2 and password1 != password2:
-            raise forms.ValidationError(
-                self.error_messages['password_mismatch'])
-        return password2
-
     def save(self, commit=True):
         user = super(MemberCreationForm, self).save(commit=False)
-        user.set_password(self.cleaned_data["password1"])
+        user.is_active = True
         if commit:
             user.save()
         return user
@@ -147,11 +133,9 @@ class MemberAdmin(UserAdmin):
 
     add_fieldsets = (
         (None, {'classes': ('wide',),
-                'fields': ('email', 'password1', 'password2')}
+                'fields': ('email', 'first_name', 'last_name',)}
          ),
     )
-
-    inlines = [UserAddressInline, MemberVotesInline]
 
     readonly_fields = ('date_joined', 'last_login', 'updated', 'deleted', 'login_as_user')
 
@@ -177,6 +161,7 @@ class MemberAdmin(UserAdmin):
     list_filter = ('user_type', 'is_active', 'is_staff', 'is_superuser', 'newsletter', 'favourite_themes', 'skills')
     list_display = ('email', 'first_name', 'last_name', 'is_staff', 'date_joined', 'is_active', 'login_as_user')
     ordering = ('-date_joined', 'email',)
+    inlines = (UserAddressInline, MemberVotesInline,)
 
     def login_as_user(self, obj):
         return format_html(
@@ -197,6 +182,7 @@ class MemberAdmin(UserAdmin):
         finally:
             # Reset fieldsets to its original value
             self.fieldsets = self.standard_fieldsets
+
         return response
 
     def __init__(self, *args, **kwargs):
@@ -205,6 +191,12 @@ class MemberAdmin(UserAdmin):
         self.list_display = (
             'email', 'first_name', 'last_name', 'is_staff', 'date_joined',
             'is_active', 'login_as_link')
+
+    def get_inline_instances(self, request, obj=None):
+        """ Override get_inline_instances so that the add form does not show inlines """
+        if not obj:
+            return []
+        return super(MemberAdmin, self).get_inline_instances(request, obj)
 
     def get_urls(self):
         urls = super(MemberAdmin, self).get_urls()

--- a/bluebottle/members/tests/test_admin.py
+++ b/bluebottle/members/tests/test_admin.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+from django.core import mail
+from django.test.utils import override_settings
+
 from tenant_schemas.urlresolvers import reverse
 
 from bluebottle.test.utils import BluebottleAdminTestCase
@@ -14,6 +17,43 @@ class GroupAdminTest(BluebottleAdminTestCase):
     def test_prepare(self):
         response = self.app.get(self.group_url, user=self.superuser)
         self.assertEqual(response.status_code, 200)
+
+
+@override_settings(SEND_WELCOME_MAIL=False)
+class MemberAdminTest(BluebottleAdminTestCase):
+    def setUp(self):
+        super(MemberAdminTest, self).setUp()
+
+        self.member_url = reverse('admin:members_member_add')
+        self.client.force_login(self.superuser)
+
+    def test_form(self):
+        response = self.client.get(self.member_url)
+        self.assertIn('Add member', response.content)
+
+    def test_invalid_form(self):
+        response = self.client.get(self.member_url)
+        csrf = self.get_csrf_token(response)
+        data = {
+            'csrfmiddlewaretoken': csrf
+        }
+        response = self.client.post(self.member_url, data)
+        self.assertIn('Please correct the errors below.', response.content)
+
+    @override_settings(SEND_WELCOME_MAIL=True)
+    def test_valid_form(self):
+        response = self.client.get(self.member_url)
+        csrf = self.get_csrf_token(response)
+        data = {
+            'email': 'bob@bob.com',
+            'first_name': 'Bob',
+            'last_name': 'Bob',
+            'csrfmiddlewaretoken': csrf
+        }
+        response = self.client.post(self.member_url, data)
+        welcome_email = mail.outbox[0]
+        self.assertEqual(welcome_email.to, ['bob@bob.com'])
+        self.assertTrue('Set password' in welcome_email.body)
 
 
 class InlineModelTestCase(BluebottleAdminTestCase):

--- a/bluebottle/test/utils.py
+++ b/bluebottle/test/utils.py
@@ -169,6 +169,13 @@ class BluebottleAdminTestCase(WebTestMixin, BluebottleTestCase):
         self.app.extra_environ['HTTP_HOST'] = str(self.tenant.domain_url)
         self.superuser = BlueBottleUserFactory.create(is_staff=True, is_superuser=True)
 
+    def get_csrf_token(self, response):
+        csrf = "name='csrfmiddlewaretoken' value='"
+        start = response.content.find(csrf) + len(csrf)
+        end = response.content.find("'", start)
+
+        return response.content[start:end]
+
 
 class SessionTestMixin(object):
     def create_session(self):


### PR DESCRIPTION
- send password reset email when creating user
- user is now active by default when created
- hide voting and address details when creating user
BB-10287 #resolve