### PR TITLE
Make celery tenant overwritable

### DIFF
--- a/bluebottle/analytics/management/commands/export_engagement_metrics.py
+++ b/bluebottle/analytics/management/commands/export_engagement_metrics.py
@@ -8,10 +8,10 @@ from django.core.management.base import BaseCommand
 from django.db import connection
 from django.db.models import Count, Sum
 from django.utils import dateparse
-from django.conf import settings
 
 from .utils import validate_date
 from bluebottle.analytics.tasks import queue_analytics_record
+from bluebottle.clients import properties
 from bluebottle.clients.models import Client
 from bluebottle.clients.utils import LocalTenant
 from bluebottle.members.models import Member
@@ -124,7 +124,7 @@ class Command(BaseCommand):
 
             fields['engagement_number'] = data['total_engaged'] + data['donations_anonymous']
 
-            if getattr(settings, 'CELERY_RESULT_BACKEND', None):
+            if getattr(properties, 'CELERY_RESULT_BACKEND', None):
                 queue_analytics_record.delay(timestamp=self.end_date, tags=tags, fields=fields)
             else:
                 queue_analytics_record(timestamp=self.end_date, tags=tags, fields=fields)
@@ -144,7 +144,7 @@ class Command(BaseCommand):
         fields['engagement_number'] = aggregated_engagement_data['total_engaged'] + \
             aggregated_engagement_data['donations_anonymous']
 
-        if getattr(settings, 'CELERY_RESULT_BACKEND', None):
+        if getattr(properties, 'CELERY_RESULT_BACKEND', None):
             queue_analytics_record.delay(timestamp=self.end_date, tags=tags, fields=fields)
         else:
             queue_analytics_record(timestamp=self.end_date, tags=tags, fields=fields)

--- a/bluebottle/analytics/utils.py
+++ b/bluebottle/analytics/utils.py
@@ -132,7 +132,7 @@ def process(instance, created):
     _merge_attrs(fields, analytics.fields)
 
     # If enabled, use celery to queue task
-    if getattr(settings, 'CELERY_RESULT_BACKEND', None):
+    if getattr(properties, 'CELERY_RESULT_BACKEND', None):
         queue_analytics_record.delay(timestamp=timestamp, tags=tags, fields=fields)
     else:
         queue_analytics_record(timestamp=timestamp, tags=tags, fields=fields)

--- a/bluebottle/orders/signals.py
+++ b/bluebottle/orders/signals.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from django.conf import settings
 from django.db import connection
 from django.dispatch.dispatcher import receiver
 from django.db.models.signals import post_save
@@ -7,6 +6,7 @@ from django.utils import timezone
 
 from django_fsm.signals import post_transition
 
+from bluebottle.clients import properties
 from bluebottle.donations.donationmail import (
     new_oneoff_donation, successful_donation_fundraiser_mail)
 from bluebottle.orders.models import Order
@@ -91,7 +91,7 @@ def _timeout_new_order(sender, instance, created=None, **kwargs):
     """
     Fail new order after 10 minutes
     """
-    if created and getattr(settings, 'CELERY_RESULT_BACKEND', None):
+    if created and getattr(properties, 'CELERY_RESULT_BACKEND', None):
         timeout_new_order.apply_async(
             [instance, connection.tenant],
             eta=timezone.now() + timedelta(minutes=10)
@@ -103,7 +103,7 @@ def _timeout_locked_order(sender, instance, created=None, **kwargs):
     """
     Fail locked order after 3 hours
     """
-    if created and getattr(settings, 'CELERY_RESULT_BACKEND', None):
+    if created and getattr(properties, 'CELERY_RESULT_BACKEND', None):
         timeout_locked_order.apply_async(
             [instance.order, connection.tenant],
             eta=timezone.now() + timedelta(hours=3)

--- a/bluebottle/projects/models.py
+++ b/bluebottle/projects/models.py
@@ -259,7 +259,7 @@ class Project(BaseProject, PreviousStatusMixin):
             fields = {
                 'total': count,
             }
-            if getattr(settings, 'CELERY_RESULT_BACKEND', None):
+            if getattr(properties, 'CELERY_RESULT_BACKEND', None):
                 queue_analytics_record.delay(timestamp=timestamp, tags=tags, fields=fields)
             else:
                 queue_analytics_record(timestamp=timestamp, tags=tags, fields=fields)

--- a/bluebottle/recurring_donations/admin.py
+++ b/bluebottle/recurring_donations/admin.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.conf.urls import url
 from django.contrib import admin
 from django.contrib.admin.filters import SimpleListFilter
@@ -8,6 +7,7 @@ from django.http.response import HttpResponseRedirect
 from django.utils.html import format_html
 from django.utils.translation import ugettext as _
 
+from bluebottle.clients import properties
 from bluebottle.recurring_donations.models import MonthlyProject
 from bluebottle.recurring_donations.tasks import prepare_monthly_batch, process_monthly_batch
 
@@ -121,7 +121,7 @@ class MonthlyBatchAdmin(admin.ModelAdmin):
     def process_batch(self, request, pk=None):
         batch = MonthlyBatch.objects.get(pk=pk)
         tenant = connection.tenant
-        if getattr(settings, 'CELERY_RESULT_BACKEND', None):
+        if getattr(properties, 'CELERY_RESULT_BACKEND', None):
             process_monthly_batch.delay(tenant=tenant, monthly_batch=batch, send_email=True)
         else:
             process_monthly_batch(tenant=tenant, monthly_batch=batch, send_email=True)

--- a/bluebottle/tasks/models.py
+++ b/bluebottle/tasks/models.py
@@ -239,7 +239,7 @@ class Task(models.Model, PreviousStatusMixin):
             # Immediately send email about realized task
             send_task_realized_mail(self, 'task_status_realized', subject, connection.tenant)
 
-            if getattr(settings, 'CELERY_RESULT_BACKEND', None):
+            if getattr(properties, 'CELERY_RESULT_BACKEND', None):
                 #  And schedule two more mails (in  3 and 6 days)
                 send_task_realized_mail.apply_async(
                     [self, 'task_status_realized_reminder', second_subject, connection.tenant],


### PR DESCRIPTION
With using `properties` instead of `settings` we can overwrite `CELERY_RESULT_BACKEND` for tenants. This way we can temporarily shut it off for VjB. Otherwise all new orders will set a timeout totally over flooding the celery queue in rabbitmq. 