### PR TITLE
Make it possible to send custom messages when confirming / rejecting

### DIFF
--- a/bluebottle/bb_tasks/templates/task_member_realized.mail.html
+++ b/bluebottle/bb_tasks/templates/task_member_realized.mail.html
@@ -3,12 +3,19 @@
 
 {% block content %}
     {% blocktrans with sender_name=sender.short_name receiver_name=receiver.short_name project_title=task.project.title task_title=task.title site_name=site.name %}
-
         Hi {{ receiver_name }},
-        <br><br>
-        You did it! The project owner {{ sender_name }} marked the task
-        <i>{{ task_title }}</i> as realized. Good job!
-        <br><br>
+    {% endblocktrans %}
+    <br><br>
+    {% if message %}
+        {{ message }}
+    {% else %}
+        {% blocktrans with sender_name=sender.short_name receiver_name=receiver.short_name project_title=task.project.title task_title=task.title site_name=site.name %}
+            You did it! The project owner {{ sender_name }} marked the task
+            <i>{{ task_title }}</i> as realized. Good job!
+        {% endblocktrans %}
+    {% endif %}
+    <br><br>
+    {% blocktrans %}
         Let's celebrate with a short comment!
     {% endblocktrans %}
 

--- a/bluebottle/bb_tasks/templates/task_member_realized.mail.txt
+++ b/bluebottle/bb_tasks/templates/task_member_realized.mail.txt
@@ -6,10 +6,16 @@
 
 Hi {{ receiver_name }},
 
+{% endblocktrans %}
+{% if message %}
+{{ message }}
+{% else %}
+{% blocktrans with sender_name=sender.short_name receiver_name=receiver.short_name project_title=task.project.title task_title=task.title site_name=site.name %}
 You did it! The project owner {{ sender_name }} marked the task '{{ task_title }}' as realized. Good job!
 
 Let's celebrate with a short comment!
 {% endblocktrans %}
+{% endif %}
 
 {% if survey_link %}
 {% blocktrans with link=survey_link %}

--- a/bluebottle/bb_tasks/templates/task_member_rejected.mail.html
+++ b/bluebottle/bb_tasks/templates/task_member_rejected.mail.html
@@ -5,11 +5,17 @@
     {% blocktrans with sender_name=sender.short_name receiver_name=receiver.short_name task_title=task.title %}
 
         Hi {{ receiver_name }},
-        <br><br>
-        Unfortunately you weren't selected for the task <i>{{ task_title }}</i>
-        <br><br>
-        No worries, have a look at some similar tasks that need your skills.
     {% endblocktrans %}
+    {% if message %}
+        {{ message }}
+    {% else %}
+        {% blocktrans with sender_name=sender.short_name receiver_name=receiver.short_name task_title=task.title %}
+            <br><br>
+            Unfortunately you weren't selected for the task <i>{{ task_title }}</i>
+            <br><br>
+            No worries, have a look at some similar tasks that need your skills.
+        {% endblocktrans %}
+    {% endif %}
 {% endblock %}
 
 {% block action %}

--- a/bluebottle/bb_tasks/templates/task_member_rejected.mail.txt
+++ b/bluebottle/bb_tasks/templates/task_member_rejected.mail.txt
@@ -6,8 +6,16 @@
 
 Hi {{ receiver_name }},
 
+{% endblocktrans %}
+{% if message %}
+{{ message }}
+{% else %}
+{% blocktrans with sender_name=sender.short_name receiver_name=receiver.short_name task_title=task.title %}
 Unfortunately you weren't selected for the task '{{ task_title }}'
+{% endblocktrans %}
+{% endif %}
 
+{% blocktrans with sender_name=sender.short_name receiver_name=receiver.short_name task_title=task.title %}
 No worries, have a look at some similar tasks that need your skills.
 {% endblocktrans %}
 {% endblock %}

--- a/bluebottle/bb_tasks/urls/api.py
+++ b/bluebottle/bb_tasks/urls/api.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 
 from ..views import (
-    TaskDetail, TaskList, TaskMemberList, TaskMemberDetail,
+    TaskDetail, TaskList, TaskMemberList, TaskMemberDetail, TaskMemberStatus,
     TaskFileList, TaskFileDetail, MyTaskList, MyTaskDetail,
     TaskPreviewList, MyTaskMemberList, SkillList, UsedSkillList)
 
@@ -19,6 +19,7 @@ urlpatterns = [
     # Task Members
     url(r'^members/$', TaskMemberList.as_view(), name='task-member-list'),
     url(r'^members/(?P<pk>\d+)$', TaskMemberDetail.as_view(), name='task-member-detail'),
+    url(r'^members/status/(?P<pk>\d+)$', TaskMemberStatus.as_view(), name='task-member-status'),
     url(r'^members/my-tasks/$', MyTaskMemberList.as_view(), name='my_task_member_list'),
 
     # Task Files

--- a/bluebottle/bb_tasks/views.py
+++ b/bluebottle/bb_tasks/views.py
@@ -16,7 +16,7 @@ from bluebottle.tasks.serializers import (
     MyTasksSerializer, TaskMemberStatusSerializer
 )
 from bluebottle.utils.permissions import (
-    RelatedResourceOwnerPermission, ResourceOwnerPermission, ResourcePermission, OneOf
+    ResourceOwnerPermission, ResourcePermission, OneOf
 )
 from bluebottle.utils.views import (
     PrivateFileView, ListAPIView, ListCreateAPIView,

--- a/bluebottle/bb_tasks/views.py
+++ b/bluebottle/bb_tasks/views.py
@@ -8,14 +8,15 @@ import django_filters
 from rest_framework import filters, serializers
 
 from bluebottle.bluebottle_drf2.pagination import BluebottlePagination
-from bluebottle.tasks.permissions import TaskPermission, TaskMemberPermission
+from bluebottle.tasks.permissions import TaskPermission, TaskMemberPermission, TaskManagerPermission
 from bluebottle.tasks.models import Task, TaskMember, TaskFile, Skill
-from bluebottle.tasks.serializers import (BaseTaskSerializer,
-                                          BaseTaskMemberSerializer, TaskFileSerializer,
-                                          TaskPreviewSerializer, MyTaskMemberSerializer,
-                                          SkillSerializer, MyTasksSerializer)
+from bluebottle.tasks.serializers import (
+    BaseTaskSerializer, BaseTaskMemberSerializer, TaskFileSerializer,
+    TaskPreviewSerializer, MyTaskMemberSerializer, SkillSerializer,
+    MyTasksSerializer, TaskMemberStatusSerializer
+)
 from bluebottle.utils.permissions import (
-    ResourceOwnerPermission, ResourcePermission, OneOf
+    RelatedResourceOwnerPermission, ResourceOwnerPermission, ResourcePermission, OneOf
 )
 from bluebottle.utils.views import (
     PrivateFileView, ListAPIView, ListCreateAPIView,
@@ -282,6 +283,15 @@ class TaskMemberDetail(RetrieveUpdateAPIView):
 
     permission_classes = (
         OneOf(ResourcePermission, TaskMemberPermission),
+    )
+
+
+class TaskMemberStatus(RetrieveUpdateAPIView):
+    queryset = TaskMember.objects.all()
+    serializer_class = TaskMemberStatusSerializer
+
+    permission_classes = (
+        OneOf(TaskManagerPermission, ResourcePermission),
     )
 
 

--- a/bluebottle/tasks/permissions.py
+++ b/bluebottle/tasks/permissions.py
@@ -23,3 +23,9 @@ class TaskMemberPermission(RelatedResourceOwnerPermission):
             self.has_parent_permission(action, user, obj.task) or
             user == obj.member
         )
+
+
+class TaskManagerPermission(RelatedResourceOwnerPermission):
+    def has_parent_permission(self, action, user, parent, model=None):
+        return user == parent.project.task_manager
+

--- a/bluebottle/tasks/permissions.py
+++ b/bluebottle/tasks/permissions.py
@@ -28,4 +28,3 @@ class TaskMemberPermission(RelatedResourceOwnerPermission):
 class TaskManagerPermission(RelatedResourceOwnerPermission):
     def has_parent_permission(self, action, user, parent, model=None):
         return user == parent.project.task_manager
-

--- a/bluebottle/tasks/taskmail.py
+++ b/bluebottle/tasks/taskmail.py
@@ -3,7 +3,6 @@ from celery import shared_task
 from django.dispatch import receiver
 from django.db import connection
 from django.db.models.signals import pre_save, pre_delete, post_save
-from django.utils import translation
 from django.utils.translation import ugettext as _
 from django.utils.safestring import mark_safe
 
@@ -20,109 +19,107 @@ class TaskMemberMailSender:
     The base class for Task Mail senders
     """
 
-    def __init__(self, instance, *args, **kwargs):
+    def __init__(self, instance, message=None, *args, **kwargs):
         self.task_member = instance
         self.task = instance.task
-        self.task_link = '/go/tasks/{0}'.format(self.task.id)
-        self.site = tenant_url()
-        self.task_list = '/go/tasks'
-        self.project_link = '/go/projects/{0}'.format(self.task.project.slug)
-        self.cur_language = translation.get_language()
+
+        self.ctx = {
+            'task': self.task,
+            'message': message,
+            'receiver': self.receiver,
+            'sender': self.task_member.member,
+            'link': '/go/tasks/{0}'.format(self.task.id),
+            'site': tenant_url(),
+            'task_list': '/go/tasks',
+            'project_link': '/go/projects/{0}'.format(self.task.project.slug),
+        }
+
+    @property
+    def receiver(self):
+        return self.task_member.member
+
+    @property
+    def sender(self):
+        return self.task.author
 
     def send(self):
-        send_mail(template_name=self.template_mail, subject=self.subject,
+        send_mail(template_name=self.template_name, subject=self.subject,
                   to=self.receiver, **self.ctx)
 
 
 class TaskMemberAppliedMail(TaskMemberMailSender):
-    def __init__(self, instance, *args, **kwargs):
-        TaskMemberMailSender.__init__(self, instance, *args, **kwargs)
-        self.template_mail = 'task_member_applied.mail'
-        self.receiver = self.task.author
+    template_name = 'task_member_applied.mail'
 
+    def __init__(self, *args, **kwargs):
+        TaskMemberMailSender.__init__(self, *args, **kwargs)
+        self.ctx['motivation'] = self.task_member.motivation
+
+    @property
+    def subject(self):
         with TenantLanguage(self.task_member.member.primary_language):
-            self.subject = _('%(member)s applied for your task') % {
+            return _('%(member)s applied for your task') % {
                 'member': self.task_member.member.get_short_name()}
 
-        self.ctx = {'task': self.task, 'receiver': self.receiver,
-                    'sender': self.task_member.member,
-                    'link': self.task_link,
-                    'site': self.site,
-                    'motivation': self.task_member.motivation}
+    @property
+    def receiver(self):
+        return self.task.author
+
+    @property
+    def sender(self):
+        return self.task_member.member
 
 
 class TaskMemberRejectMail(TaskMemberMailSender):
-    def __init__(self, instance, *args, **kwargs):
-        TaskMemberMailSender.__init__(self, instance, *args, **kwargs)
+    template_name = 'task_member_rejected.mail'
 
-        self.template_mail = 'task_member_rejected.mail'
-        self.receiver = self.task_member.member
-
+    @property
+    def subject(self):
         with TenantLanguage(self.receiver.primary_language):
-            self.subject = _('%(author)s didn\'t select you for a task') % {
+            return _('%(author)s didn\'t select you for a task') % {
                 'author': self.task.author.get_short_name()}
-
-        self.ctx = {'task': self.task, 'receiver': self.receiver,
-                    'sender': self.task.author,
-                    'link': self.task_link,
-                    'site': self.site,
-                    'task_list': self.task_list}
 
 
 class TaskMemberAcceptedMail(TaskMemberMailSender):
-    def __init__(self, instance, *args, **kwargs):
-        TaskMemberMailSender.__init__(self, instance, *args, **kwargs)
+    template_name = 'task_member_accepted.mail'
 
-        self.template_mail = 'task_member_accepted.mail'
-        self.receiver = self.task_member.member
-
+    @property
+    def subject(self):
         with TenantLanguage(self.receiver.primary_language):
-            self.subject = _('%(author)s assigned you to a task') % {
+            return _('%(author)s assigned you to a task') % {
                 'author': self.task.author.get_short_name()}
-
-        self.ctx = {'task': self.task, 'receiver': self.receiver,
-                    'sender': self.task.author,
-                    'link': self.task_link,
-                    'site': self.site}
 
 
 class TaskMemberRealizedMail(TaskMemberMailSender):
-    def __init__(self, instance, *args, **kwargs):
-        TaskMemberMailSender.__init__(self, instance, *args, **kwargs)
+    template_name = 'task_member_realized.mail'
 
-        self.template_mail = 'task_member_realized.mail'
-        self.receiver = self.task_member.member
-
-        with TenantLanguage(self.receiver.primary_language):
-            self.subject = _('You realised a task!')
+    def __init__(self, *args, **kwargs):
+        TaskMemberMailSender.__init__(self, *args, **kwargs)
 
         survey_url = Survey.url(self.task)
+        self.ctx['survey_link'] = mark_safe(survey_url) if survey_url else None
 
-        self.ctx = {'task': self.task, 'receiver': self.receiver,
-                    'sender': self.task.author,
-                    'link': self.task_link,
-                    'survey_link': mark_safe(survey_url) if survey_url else None,
-                    'site': self.site,
-                    'task_list': self.task_list,
-                    'project_link': self.project_link}
+    @property
+    def subject(self):
+        with TenantLanguage(self.receiver.primary_language):
+            return _('You realised a task!')
 
 
 class TaskMemberWithdrawMail(TaskMemberMailSender):
-    def __init__(self, instance, *args, **kwargs):
-        TaskMemberMailSender.__init__(self, instance, *args, **kwargs)
+    template_name = 'task_member_withdrew.mail'
 
-        self.template_mail = 'task_member_withdrew.mail'
-        self.receiver = self.task.author
-
+    @property
+    def subject(self):
         with TenantLanguage(self.receiver.primary_language):
-            self.subject = _('%(member)s withdrew from a task') % {
+            return _('%(member)s withdrew from a task') % {
                 'member': self.task_member.member.get_short_name()}
 
-        self.ctx = {'task': self.task, 'receiver': self.receiver,
-                    'sender': self.task_member.member,
-                    'link': self.task_link, 'site': self.site,
-                    'task_list': self.task_list,
-                    'project_link': self.project_link}
+    @property
+    def receiver(self):
+        return self.task.author
+
+    @property
+    def sender(self):
+        return self.task_member.member
 
 
 class TaskMemberMailAdapter:
@@ -141,12 +138,12 @@ class TaskMemberMailAdapter:
 
     mail_sender = None
 
-    def __init__(self, instance, status=None):
+    def __init__(self, instance, status=None, message=None):
         if not status:
             status = instance.status
         # If a mailer is provided for the task status, set the mail_sender
         if self.TASK_MEMBER_MAIL.get(status):
-            self.mail_sender = self.TASK_MEMBER_MAIL.get(status)(instance)
+            self.mail_sender = self.TASK_MEMBER_MAIL.get(status)(instance, message)
 
     def send_mail(self):
         if self.mail_sender:
@@ -210,7 +207,11 @@ def send_deadline_to_apply_passed_mail(task, subject, tenant):
 
 @receiver(post_save, weak=False, sender=TaskMember)
 def new_reaction_notification(sender, instance, created, **kwargs):
-    if instance.status != instance._original_status or created:
+    if (
+        instance.status != instance._original_status and
+        not getattr(instance, 'skip_mail', False) or
+        created
+    ):
         mailer = TaskMemberMailAdapter(instance)
         mailer.send_mail()
 

--- a/bluebottle/tasks/tests/test_api.py
+++ b/bluebottle/tasks/tests/test_api.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 import mock
 
 from django.contrib.auth.models import Group, Permission
+from django.core import mail
 from django.core.urlresolvers import reverse
 
 from rest_framework import status
@@ -713,6 +714,110 @@ class TestMyTasksPermissions(BluebottleTestCase):
 
         response = self.client.get(self.my_task_member_url, token=self.user_token)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+class TestTaskMemberStatusAPI(BluebottleTestCase):
+    """
+    Test methods for getting tasks that you are a member of.
+    """
+
+    def setUp(self):
+        super(TestTaskMemberStatusAPI, self).setUp()
+
+        self.init_projects()
+
+        self.user = BlueBottleUserFactory.create()
+        self.member = BlueBottleUserFactory.create()
+
+        self.user_token = "JWT {0}".format(self.user.get_jwt_token())
+
+        self.project = ProjectFactory.create(task_manager=self.user)
+        self.task = TaskFactory.create(project=self.project, people_needed=2)
+        self.task_member = TaskMemberFactory.create(task=self.task, member=self.member)
+
+        self.url = reverse('task-member-status', args=(self.task_member.pk, ))
+
+    def test_read(self):
+        """
+        Task mamangers can read the status
+        """
+        response = self.client.get(self.url, token=self.user_token)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.keys(), ['id', 'member', 'status', 'permissions'])
+
+    def test_set_status_realized(self):
+        """
+        Task mamangers can read the status
+        """
+        mail.outbox = []
+        data = {
+            'status': 'realized',
+            'message': 'Just a test message'
+        }
+        response = self.client.put(self.url, data=data, token=self.user_token)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['status'], 'realized')
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertTrue(
+            data['message'] in mail.outbox[0].alternatives[0][0]
+        )
+        self.assertTrue(
+            data['message'] in mail.outbox[0].body
+        )
+
+    def test_set_status_realized_twice(self):
+        """
+        Task mamangers can read the status
+        """
+        mail.outbox = []
+        data = {
+            'status': 'realized',
+            'message': 'Just a test message'
+        }
+        response = self.client.put(self.url, data=data, token=self.user_token)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.client.put(self.url, data=data, token=self.user_token)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_set_status_rejected(self):
+        """
+        Task mamangers can read the status
+        """
+        mail.outbox = []
+        data = {
+            'status': 'rejected',
+            'message': 'Just a test message'
+        }
+        response = self.client.put(self.url, data=data, token=self.user_token)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['status'], 'rejected')
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertTrue(
+            data['message'] in mail.outbox[0].alternatives[0][0]
+        )
+        self.assertTrue(
+            data['message'] in mail.outbox[0].body
+        )
+
+    def test_set_status_member(self):
+        """
+        Task mamangers can read the status
+        """
+        data = {
+            'status': 'realized',
+            'message': 'Just a test message'
+        }
+
+        token = "JWT {0}".format(self.member.get_jwt_token())
+        response = self.client.put(self.url, data=data, token=token)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
 class TestProjectTaskAPIPermissions(BluebottleTestCase):


### PR DESCRIPTION
users.

Adds an API endpoint /api/tasks/members/status/id that makes it possible
to get and set the status of a taskmember. A message has to be passed in
that will become part of the email send to the member.

BB-9498 #resolve