### PR TITLE
Fix permission checking for reward export.

### DIFF
--- a/bluebottle/donations/admin.py
+++ b/bluebottle/donations/admin.py
@@ -110,8 +110,9 @@ class DonationAdmin(admin.ModelAdmin):
     export_fields = [
         ('project', 'project'),
         ('order__user', 'user'),
+        ('order__user__full_name', 'name'),
         ('order__user__remote_id', 'remote id'),
-        ('name', 'name'),
+        ('name', 'name on donation'),
         ('fundraiser', 'fundraiser'),
         ('amount', 'amount'),
         ('created', 'created'),

--- a/bluebottle/projects/admin.py
+++ b/bluebottle/projects/admin.py
@@ -440,7 +440,7 @@ class ProjectAdmin(AdminImageMixin, ImprovedModelForm):
         This allows the project initiator to contact all recipients.
         """
         project = Project.objects.get(pk=pk)
-        if not request.user.has_perm('rewards.read_reward'):
+        if not request.user.is_staff:
             return HttpResponseForbidden('Missing permission: rewards.read_reward')
 
         response = HttpResponse(content_type='text/csv')

--- a/bluebottle/projects/templates/admin/projects/project/change_form.html
+++ b/bluebottle/projects/templates/admin/projects/project/change_form.html
@@ -20,7 +20,7 @@
             </a>
         {% endif %}
     </li>
-    {% if perms.rewards.read_reward and original.reward_set.count %}
+    {% if user.is_staff and original.reward_set.count %}
     <li>
         <a href="{% url 'admin:projects_project_export_rewards' object_id %}" style="background-color: darkgreen">
             {% trans  "Export Rewards" %}

--- a/bluebottle/projects/tests/test_admin.py
+++ b/bluebottle/projects/tests/test_admin.py
@@ -43,8 +43,9 @@ class MockRequest:
 
 
 class MockUser:
-    def __init__(self, perms=None):
+    def __init__(self, perms=None, is_staff=True):
         self.perms = perms or []
+        self.is_staff = is_staff
 
     def has_perm(self, perm):
         return perm in self.perms
@@ -248,7 +249,7 @@ class TestProjectAdmin(BluebottleTestCase):
 
     def test_export_rewards(self):
         request = self.request_factory.get('/')
-        request.user = MockUser(['rewards.read_reward'])
+        request.user = MockUser()
 
         project = ProjectFactory.create()
         reward = RewardFactory.create(project=project, amount=Money(10, 'EUR'))
@@ -280,7 +281,7 @@ class TestProjectAdmin(BluebottleTestCase):
 
     def test_export_rewards_anonymous(self):
         request = self.request_factory.get('/')
-        request.user = MockUser(['rewards.read_reward'])
+        request.user = MockUser()
 
         project = ProjectFactory.create()
         reward = RewardFactory.create(project=project, amount=Money(10, 'EUR'))
@@ -314,7 +315,7 @@ class TestProjectAdmin(BluebottleTestCase):
 
     def test_export_rewards_forbidden(self):
         request = self.request_factory.get('/')
-        request.user = MockUser([])
+        request.user = MockUser(is_staff=False)
 
         project = ProjectFactory.create()
         response = self.project_admin.export_rewards(request, project.id)


### PR DESCRIPTION
- Just check if user is staff. There are no read permissions in the
  admin
- Add user's name to donation export

BB-10995 #resolve
BB-11141 #resolve