### PR TITLE
Fix payment handling

### DIFF
--- a/bluebottle/bb_orders/models.py
+++ b/bluebottle/bb_orders/models.py
@@ -118,6 +118,20 @@ class BaseOrder(models.Model, FSMTransition):
         if save:
             self.save()
 
+    def process_order_payment_status_change(self, order_payment, **kwargs):
+        # Get the mapped status OrderPayment to Order
+        new_order_status = self.get_status_mapping(kwargs['target'])
+
+        successful_payments = self.order_payments.\
+            filter(status__in=['settled', 'authorized']).\
+            exclude(id=order_payment.id).count()
+
+        # If this order has other order_payments that were successful it should no change status
+        if successful_payments:
+            pass
+        else:
+            self.transition_to(new_order_status)
+
     def __unicode__(self):
         return "{0} : {1}".format(self.id, self.created)
 

--- a/bluebottle/bb_orders/signals.py
+++ b/bluebottle/bb_orders/signals.py
@@ -42,9 +42,7 @@ def _order_payment_status_changed(sender, instance, **kwargs):
     # Get the Order from the OrderPayment
     order = instance.order
 
-    # Get the mapped status OrderPayment to Order
-    new_order_status = order.get_status_mapping(kwargs['target'])
-    order.transition_to(new_order_status)
+    order.process_order_payment_status_change(order_payment=instance, **kwargs)
 
 
 @receiver(order_requested)

--- a/bluebottle/payments/signals.py
+++ b/bluebottle/payments/signals.py
@@ -21,7 +21,7 @@ def order_payment_changed(sender, instance, **kwargs):
     default_status = StatusDefinition.CREATED
 
     # Signal new status if current status is the default value
-    if (instance.status == default_status):
+    if instance.status == default_status:
         signal_kwargs = {
             'sender': sender,
             'instance': instance,

--- a/bluebottle/payments/tasks.py
+++ b/bluebottle/payments/tasks.py
@@ -1,0 +1,14 @@
+from celery import shared_task
+
+from bluebottle.payments.exception import PaymentException
+from bluebottle.payments.services import PaymentService
+
+
+@shared_task
+def check_payment_statuses(order_payments):
+    for order_payment in order_payments:
+        service = PaymentService(order_payment)
+        try:
+            service.check_payment_status()
+        except (PaymentException, TypeError):
+            pass

--- a/bluebottle/payments/tests/test_models.py
+++ b/bluebottle/payments/tests/test_models.py
@@ -125,6 +125,29 @@ class PaymentTestCase(BluebottleTestCase):
             'onepercentclub.com donation {id}'.format(id=self.order_payment.id)
         )
 
+    def test_multiple_payments_to_an_order(self):
+        """
+        Test that a second order_payment can't transition an successful order.
+        """
+
+        second_order_payment = OrderPaymentFactory.create(order=self.order)
+
+        self.order_payment.started()
+        self.order_payment.authorized()
+        self.order_payment.settled()
+        self.order_payment.save()
+
+        # Order should be successful now
+        self.assertEqual(self.order.status, 'success')
+
+        second_order_payment.started()
+        second_order_payment.save()
+        second_order_payment.failed()
+        second_order_payment.save()
+
+        # Order should still be successful
+        self.assertEqual(self.order.status, 'success')
+
 
 class OrderPaymentTestCase(BluebottleTestCase):
     def setUp(self):

--- a/bluebottle/payments_docdata/admin.py
+++ b/bluebottle/payments_docdata/admin.py
@@ -30,10 +30,15 @@ class AbstractDocdataPaymentAdmin(PolymorphicChildModelAdmin):
     inlines = (PaymentLogEntryInline, DocdataTransactionInline)
 
     readonly_fields = (
-        'order_payment_link', 'merchant_order_id', 'payment_cluster_link',
-        'payment_cluster_key', 'ideal_issuer_id', 'default_pm',
+        'currency',
+        'default_pm',
+        'ideal_issuer_id',
+        'merchant_order_id',
+        'order_payment_link',
+        'payment_cluster_key',
+        'payment_cluster_link',
         'total_gross_amount',
-        'currency')
+    )
 
     def order_payment_link(self, obj):
         object = obj.order_payment
@@ -59,10 +64,26 @@ class DocdataPaymentAdmin(AbstractDocdataPaymentAdmin):
     model = DocdataPayment
 
     readonly_fields = AbstractDocdataPaymentAdmin.readonly_fields + (
-        'ip_address', 'customer_id', 'email', 'first_name', 'last_name',
-        'address', 'postal_code', 'city', 'country',
+        'address',
+        'city',
+        'country',
+        'customer_id',
+        'email',
+        'first_name',
+        'ip_address',
+        'language',
+        'last_name',
+        'order_payment',
+        'postal_code',
+        'payment_cluster_id',
+        'total_registered',
+        'total_shopper_pending',
+        'total_acquirer_approved',
+        'total_acquirer_pending',
+        'total_captured',
+        'total_refunded',
+        'total_charged_back',
     )
-
     fields = ('status',) + readonly_fields
 
 


### PR DESCRIPTION
* Don't transition successful orders to failed if one (order)payment fails
* Make bulk checking payment status check a celery task
* Friendly errors when doing payment status check (avoid server errors)

*NB: Since this changes some inner workings of payments it needs thorough reviewing.*