### PR TITLE
Since adminsortable uses csrf protected ajax requests for sorting, do…

### DIFF
--- a/bluebottle/settings/base.py
+++ b/bluebottle/settings/base.py
@@ -400,7 +400,6 @@ TENANT_APPS = (
 INSTALLED_APPS = list(SHARED_APPS) + [app for app in TENANT_APPS if app not in SHARED_APPS]
 
 CSRF_COOKIE_SECURE = True
-CSRF_COOKIE_HTTPONLY = True
 
 TENANT_MODEL = "clients.Client"
 TENANT_PROPERTIES = "bluebottle.clients.properties"


### PR DESCRIPTION
… not mark the csrf token as

http only.