### PR TITLE
Since tenants regularly changes slides that appear on the homepage,

### DIFF
--- a/bluebottle/cms/content_plugins.py
+++ b/bluebottle/cms/content_plugins.py
@@ -3,7 +3,7 @@ from django.utils.translation import ugettext_lazy as _
 from fluent_contents.extensions import plugin_pool, ContentPlugin
 
 from bluebottle.cms.admin import (
-    QuoteInline, StatInline, SlideInline, StepInline, LogoInline, LinkInline,
+    QuoteInline, StatInline, StepInline, LogoInline, LinkInline,
     GreetingInline
 )
 from bluebottle.cms.models import (

--- a/bluebottle/cms/content_plugins.py
+++ b/bluebottle/cms/content_plugins.py
@@ -91,7 +91,6 @@ class TasksBlockPlugin(CMSContentPlugin):
 @plugin_pool.register
 class SlidesBlockPlugin(CMSContentPlugin):
     model = SlidesContent
-    inlines = [SlideInline]
 
     category = _('Homepage')
 

--- a/bluebottle/cms/serializers.py
+++ b/bluebottle/cms/serializers.py
@@ -18,7 +18,7 @@ from bluebottle.cms.models import (
     Stat, StatsContent, ResultPage, HomePage, QuotesContent, SurveyContent, Quote,
     ProjectImagesContent, ProjectsContent, ShareResultsContent, ProjectsMapContent,
     SupporterTotalContent, TasksContent, CategoriesContent, StepsContent, LocationsContent,
-    SlidesContent, Slide, Step, Logo, LogosContent, ContentLink, LinksContent,
+    SlidesContent, Step, Logo, LogosContent, ContentLink, LinksContent,
     SitePlatformSettings, WelcomeContent
 )
 from bluebottle.geo.serializers import LocationSerializer

--- a/bluebottle/cms/serializers.py
+++ b/bluebottle/cms/serializers.py
@@ -23,6 +23,7 @@ from bluebottle.cms.models import (
 )
 from bluebottle.geo.serializers import LocationSerializer
 from bluebottle.projects.serializers import ProjectPreviewSerializer
+from bluebottle.slides.models import Slide
 from bluebottle.surveys.serializers import QuestionSerializer
 from bluebottle.utils.fields import SafeField
 
@@ -197,7 +198,16 @@ class SlideSerializer(serializers.ModelSerializer):
 
 
 class SlidesContentSerializer(serializers.ModelSerializer):
-    slides = SlideSerializer(many=True)
+    slides = serializers.SerializerMethodField()
+
+    def get_slides(self, instance):
+        slides = Slide.objects.published().filter(
+            language=instance.language_code
+        )
+
+        return SlideSerializer(
+            slides, many=True, context=self.context
+        ).to_representation(slides)
 
     class Meta:
         model = SlidesContent

--- a/bluebottle/cms/tests/test_api.py
+++ b/bluebottle/cms/tests/test_api.py
@@ -275,11 +275,17 @@ class HomePageTestCase(BluebottleTestCase):
             self.assertTrue(project['is_campaign'])
 
     def test_slides(self):
-        block = SlidesContent.objects.create_for_placeholder(self.placeholder)
+        SlidesContent.objects.create_for_placeholder(self.placeholder)
         image = File(open('./bluebottle/cms/tests/test_images/upload.png'))
 
         for i in range(0, 4):
-            SlideFactory(block=block, image=image)
+            SlideFactory(
+                image=image,
+                sequence=i,
+                publication_date=now(),
+                status='published',
+                language='en'
+            )
 
         response = self.client.get(self.url)
 
@@ -293,14 +299,21 @@ class HomePageTestCase(BluebottleTestCase):
             self.assertTrue(slide['image'].endswith('png'))
 
     def test_slides_svg(self):
-        block = SlidesContent.objects.create_for_placeholder(self.placeholder)
+        SlidesContent.objects.create_for_placeholder(self.placeholder)
         image = File(open('./bluebottle/cms/tests/test_images/upload.svg'))
 
         for i in range(0, 4):
-            SlideFactory(block=block, image=image)
+            SlideFactory(
+                image=image,
+                sequence=i,
+                publication_date=now(),
+                status='published',
+                language='en'
+            )
 
         response = self.client.get(self.url)
 
+        self.assertEqual(len(response.data['blocks'][0]['slides']), 4)
         self.assertEqual(response.status_code, 200)
 
         for slide in response.data['blocks'][0]['slides']:

--- a/bluebottle/test/factory_models/cms.py
+++ b/bluebottle/test/factory_models/cms.py
@@ -4,10 +4,11 @@ import factory
 from django.utils.timezone import now
 
 from bluebottle.cms.models import (
-    ResultPage, HomePage, Stat, Quote, Slide,
+    ResultPage, HomePage, Stat, Quote,
     SiteLinks, LinkGroup, Link, LinkPermission,
     Step, ContentLink, Greeting
 )
+from bluebottle.slides.models import Slide
 from bluebottle.test.factory_models.utils import LanguageFactory
 
 


### PR DESCRIPTION
and training them in changing the homepage in the admin is too
complicated, let the homepage use the existing slides models.

The new slides models are left in, because when we do expose changing
the homepage to normal users, we will need them again.