### PR TITLE
Make it possible to extend the deadline of a task until after the

### DIFF
--- a/bluebottle/tasks/serializers.py
+++ b/bluebottle/tasks/serializers.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from rest_framework import serializers
 from django.utils.translation import ugettext_lazy as _
 
@@ -110,10 +111,13 @@ class BaseTaskSerializer(serializers.ModelSerializer):
             # The date has not changed: Do not validate
             return data
 
-        if not data['deadline'] or data['deadline'] > data['project'].deadline:
-            raise serializers.ValidationError(
-                {'deadline': [_("The deadline must be before the project deadline.")]}
-            )
+        project_started = data['project'].campaign_started or data['project'].created
+        if data.get('deadline') > project_started + timedelta(days=365):
+            raise serializers.ValidationError({
+                'deadline': [
+                    _("The deadline can not be more then a year after the project deadline")
+                ]
+            })
 
         if not data['deadline_to_apply'] or data['deadline_to_apply'] > data['deadline']:
             raise serializers.ValidationError(
@@ -145,6 +149,24 @@ class BaseTaskSerializer(serializers.ModelSerializer):
             'title',
             'type',
         )
+
+    def _check_project_deadline(self, instance, validated_data):
+        project = validated_data['project']
+        if instance.deadline > project.deadline:
+            project.deadline = instance.deadline
+            project.save()
+
+    def create(self, validated_data):
+        instance = super(BaseTaskSerializer, self).create(validated_data)
+        self._check_project_deadline(instance, validated_data)
+
+        return instance
+
+    def update(self, instance, validated_data):
+        result = super(BaseTaskSerializer, self).update(instance, validated_data)
+        self._check_project_deadline(instance, validated_data)
+
+        return result
 
 
 class MyTaskPreviewSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
project deadline

When a task deadline is extend to after the project deadline, also move
the project deadline.

Project deadlines cannot be more then a year after the project started.

BB-11282 #resolve