### PR TITLE
Make sure we flash the content types cache when entering the LocalTenant

### DIFF
--- a/bluebottle/analytics/management/commands/create_report_fixtures.py
+++ b/bluebottle/analytics/management/commands/create_report_fixtures.py
@@ -1,7 +1,6 @@
 import os
 import yaml
 
-from django.db import connection
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
@@ -23,7 +22,6 @@ class Command(BaseCommand):
 
     def generate_fixtures(self, client_name, skip=50):
         client = Client.objects.get(client_name=client_name)
-        connection.set_tenant(client)
         results = {
             'members': [],
             'projects': [],

--- a/bluebottle/analytics/management/commands/create_report_views.py
+++ b/bluebottle/analytics/management/commands/create_report_views.py
@@ -39,7 +39,6 @@ class Command(BaseCommand):
         sql = "\n".join(sql_lines)
 
         for client in clients:
-            connection.set_tenant(client)
             with LocalTenant(client, clear_tenant=True):
                 cursor = connection.cursor()
                 cursor.execute(sql)

--- a/bluebottle/analytics/management/commands/export_analytics_data.py
+++ b/bluebottle/analytics/management/commands/export_analytics_data.py
@@ -4,7 +4,6 @@ import logging
 
 import django.apps
 from django.core.management.base import BaseCommand
-from django.db import connection
 from django.test.utils import override_settings
 from django.utils import dateparse
 
@@ -49,8 +48,6 @@ class Command(BaseCommand):
 
         for client in Client.objects.all():
             if tenants is None or client.client_name in tenants:
-                connection.set_tenant(client)
-
                 with LocalTenant(client, clear_tenant=True):
                     logger.info('export tenant:{}'.format(client.schema_name))
                     models = django.apps.apps.get_models()

--- a/bluebottle/analytics/management/commands/export_engagement_metrics.py
+++ b/bluebottle/analytics/management/commands/export_engagement_metrics.py
@@ -5,7 +5,6 @@ from datetime import datetime, timedelta
 
 import xlsxwriter
 from django.core.management.base import BaseCommand
-from django.db import connection
 from django.db.models import Count, Sum
 from django.utils import dateparse
 
@@ -97,7 +96,6 @@ class Command(BaseCommand):
 
         for client in Client.objects.all():
             if self.tenants is None or client.client_name in self.tenants:
-                connection.set_tenant(client)
                 with LocalTenant(client, clear_tenant=True):
                     logger.info('export tenant:{} start_date:{} end_date:{}'
                                 .format(client.client_name,
@@ -200,7 +198,6 @@ class Command(BaseCommand):
         with xlsxwriter.Workbook(file_name) as workbook:
             for client in Client.objects.all():
                 if self.tenants is None or client.client_name in self.tenants:
-                    connection.set_tenant(client)
                     with LocalTenant(client, clear_tenant=True):
                         logger.info('export tenant:{}'.format(client.client_name))
                         raw_data = self.generate_raw_data()

--- a/bluebottle/analytics/management/commands/export_participation_metrics.py
+++ b/bluebottle/analytics/management/commands/export_participation_metrics.py
@@ -148,7 +148,6 @@ class Command(BaseCommand):
         file_name = self.get_file_name()
         self.file_path = self.get_xls_file_name(file_name)
         client = Client.objects.get(client_name=self.tenant)
-        connection.set_tenant(client)
 
         with xlsxwriter.Workbook(self.file_path,
                                  {'default_date_format': 'dd/mm/yy', 'remove_timezone': True}) as workbook:

--- a/bluebottle/analytics/management/commands/export_report.py
+++ b/bluebottle/analytics/management/commands/export_report.py
@@ -129,7 +129,6 @@ class Command(BaseCommand):
         file_name = self.get_file_name()
         self.file_path = self.get_xls_file_name(file_name)
         client = Client.objects.get(client_name=self.tenant)
-        connection.set_tenant(client)
 
         with xlsxwriter.Workbook(self.file_path,
                                  {'default_date_format': 'dd/mm/yy', 'remove_timezone': True}) as workbook:

--- a/bluebottle/clients/management/commands/bulk_import.py
+++ b/bluebottle/clients/management/commands/bulk_import.py
@@ -10,7 +10,6 @@ from moneyed.classes import Money
 
 from django.core.files import File
 from django.core.management.base import BaseCommand
-from django.db import connection
 from django.utils.timezone import now
 from django.contrib.contenttypes.models import ContentType
 
@@ -70,10 +69,7 @@ class Command(BaseCommand):
                             help="Models you want to import, can be multiple e.g. -m users wallposts")
 
     def handle(self, *args, **options):
-
         client = Client.objects.get(client_name=options['tenant'])
-        connection.set_tenant(client)
-
         self.upload = options['upload']
 
         with LocalTenant(client, clear_tenant=True):

--- a/bluebottle/clients/utils.py
+++ b/bluebottle/clients/utils.py
@@ -8,6 +8,7 @@ import re
 from babel.numbers import get_currency_symbol, get_currency_name
 from django.db import connection, ProgrammingError
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import get_language
 
 from djmoney_rates.utils import get_rate
@@ -34,7 +35,9 @@ class LocalTenant(object):
 
     def __enter__(self):
         if self.tenant:
+            connection.set_tenant(self.tenant)
             properties.set_tenant(self.tenant)
+            ContentType.objects.clear_cache()
 
     def __exit__(self, type, value, traceback):
         if self.clear_tenant:

--- a/bluebottle/cms/management/commands/migrate_homepage.py
+++ b/bluebottle/cms/management/commands/migrate_homepage.py
@@ -1,7 +1,6 @@
 from StringIO import StringIO
 from django.apps import apps
 from django.core.management.base import BaseCommand
-from django.db import connection
 from django.contrib.contenttypes.models import ContentType
 from django.core.files import File
 
@@ -101,7 +100,6 @@ class Command(BaseCommand):
 
         for client in tenants:
             print "\n\nCreating homepage for {}".format(client.name)
-            connection.set_tenant(client)
             with LocalTenant(client, clear_tenant=True):
                 ContentType.objects.clear_cache()
 

--- a/bluebottle/common/tasks.py
+++ b/bluebottle/common/tasks.py
@@ -23,9 +23,6 @@ def _send_celery_mail(msg, tenant=None, send=False):
         to utf_8 so we don't get Unicode errors.
     """
     with LocalTenant(tenant, clear_tenant=True):
-        # if tenant:
-        #    properties.set_tenant(tenant)
-
         body = msg.body
         if isinstance(body, unicode):
             body = msg.body.encode('utf_8')
@@ -98,12 +95,6 @@ def _post_to_facebook(instance, tenant=None):
 
     if not tenant:
         return
-
-    from tenant_schemas.utils import get_tenant_model
-    from django.db import connection
-
-    db_tenant = get_tenant_model().objects.get(client_name=tenant.client_name)
-    connection.set_tenant(db_tenant)
 
     with LocalTenant(tenant, clear_tenant=True):
         social = instance.author.social_auth.get(provider='facebook')

--- a/bluebottle/donations/management/commands/export_donations.py
+++ b/bluebottle/donations/management/commands/export_donations.py
@@ -1,6 +1,5 @@
 import json
 from django.core.management.base import BaseCommand
-from django.db import connection
 
 from bluebottle.orders.models import Order
 from bluebottle.clients.models import Client
@@ -18,9 +17,13 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         results = []
         for client in Client.objects.all():
-            connection.set_tenant(client)
             with LocalTenant(client, clear_tenant=True):
-                orders = Order.objects.filter(status__in=('pending', 'success'))
+                orders = Order.objects.filter(
+                    status__in=('pending', 'success')
+                ).exclude(
+                    order_payments__payment_method=''
+                )
+
                 if options['start']:
                     orders = orders.filter(created__gte=options['start'])
                 if options['end']:

--- a/bluebottle/members/management/commands/convert_wp_passwords.py
+++ b/bluebottle/members/management/commands/convert_wp_passwords.py
@@ -25,8 +25,6 @@ class Command(BaseCommand):
         """
         try:
             client = Client.objects.get(client_name=options['tenant'])
-            connection.set_tenant(client)
-
         except Client.DoesNotExist:
             logger.error("You must specify a valid tenant with -t or --tenant.")
             tenants = Client.objects.all().values_list('client_name', flat=True)

--- a/bluebottle/members/management/commands/convert_wp_passwords.py
+++ b/bluebottle/members/management/commands/convert_wp_passwords.py
@@ -3,7 +3,6 @@ import sys
 
 from django.contrib.auth.hashers import get_hasher
 from django.core.management.base import BaseCommand
-from django.db import connection
 
 from bluebottle.clients.models import Client
 from bluebottle.clients.utils import LocalTenant

--- a/bluebottle/orders/tasks.py
+++ b/bluebottle/orders/tasks.py
@@ -2,8 +2,6 @@ import logging
 
 from celery import shared_task
 
-from django.db import connection
-
 from bluebottle.clients.utils import LocalTenant
 from bluebottle.orders.models import Order
 from bluebottle.utils.utils import StatusDefinition
@@ -19,7 +17,6 @@ def timeout_new_order(order, tenant):
     never be finished.
     """
     logger.info("Timeing out order {}".format(order))
-    connection.set_tenant(tenant)
 
     with LocalTenant(tenant, clear_tenant=True):
         order = Order.objects.get(pk=order.pk)
@@ -35,7 +32,6 @@ def timeout_locked_order(order, tenant):
     will never be  payed.
     """
     logger.info("Timeing out order {}".format(order))
-    connection.set_tenant(tenant)
 
     with LocalTenant(tenant, clear_tenant=True):
         order = Order.objects.get(pk=order.pk)

--- a/bluebottle/payouts/management/commands/export_payouts.py
+++ b/bluebottle/payouts/management/commands/export_payouts.py
@@ -1,6 +1,5 @@
 import json
 from django.core.management.base import BaseCommand
-from django.db import connection
 
 from bluebottle.donations.models import Donation
 from bluebottle.payouts.models import ProjectPayout
@@ -30,7 +29,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         results = []
         for client in Client.objects.all():
-            connection.set_tenant(client)
             with LocalTenant(client, clear_tenant=True):
 
                 payouts = ProjectPayout.objects.filter(amount_payable__gt=0)

--- a/bluebottle/payouts_dorado/management/commands/export_keys.py
+++ b/bluebottle/payouts_dorado/management/commands/export_keys.py
@@ -1,6 +1,5 @@
 import json
 
-from django.db import connection
 from django.core.management.base import BaseCommand, CommandError
 
 from rest_framework.authtoken.models import Token
@@ -44,7 +43,6 @@ class Command(BaseCommand):
 
         tokens = []
         for tenant in tenants:
-            connection.set_tenant(tenant)
             with LocalTenant(tenant):
                 tokens += [
                     {

--- a/bluebottle/projects/management/commands/cron_status_realised.py
+++ b/bluebottle/projects/management/commands/cron_status_realised.py
@@ -1,5 +1,4 @@
 from django.core.management.base import BaseCommand, CommandError
-from django.db import connection
 from django.utils.timezone import now
 
 from bluebottle.bb_projects.models import ProjectPhase
@@ -26,8 +25,6 @@ class Command(BaseCommand):
         need to update projects which haven't been funded but have expired,
         or they have been overfunded and have expired.
         """
-        connection.set_tenant(client)
-
         with LocalTenant(client, clear_tenant=True):
 
             self.stdout.write("Checking deadlines for client {0}".

--- a/bluebottle/projects/tasks.py
+++ b/bluebottle/projects/tasks.py
@@ -4,7 +4,6 @@ import logging
 
 from celery import shared_task
 from django.core.management import call_command
-from django.db import connection
 
 from bluebottle.clients.models import Client
 from bluebottle.clients.utils import LocalTenant
@@ -30,7 +29,6 @@ def update_popularity():
     logger.info("Updating projects popularity using Celery")
 
     for tenant in Client.objects.all():
-        connection.set_tenant(tenant)
         with LocalTenant(tenant, clear_tenant=True):
             Project.update_popularity()
 
@@ -48,7 +46,6 @@ def update_exchange_rates():
 
     logger.info("Updating amounts of all running projects")
     for tenant in Client.objects.all():
-        connection.set_tenant(tenant)
         with LocalTenant(tenant, clear_tenant=True):
             for project in Project.objects.filter(status__slug='campaign'):
                 project.update_amounts()
@@ -59,14 +56,12 @@ def update_project_status_stats():
     """ Calculates the no. of projects per status for a tenant
     """
     for tenant in Client.objects.all():
-        connection.set_tenant(tenant)
         with LocalTenant(tenant, clear_tenant=True):
             Project.update_status_stats(tenant=tenant)
 
 
 @shared_task
 def refund_project(tenant, project):
-    connection.set_tenant(tenant)
     with LocalTenant(tenant, clear_tenant=True):
         for donation in project.donations:
             service = PaymentService(donation.order.order_payment)

--- a/bluebottle/recurring_donations/management/commands/process_monthly_donations.py
+++ b/bluebottle/recurring_donations/management/commands/process_monthly_donations.py
@@ -2,7 +2,6 @@ import sys
 import logging
 
 from django.core.management.base import BaseCommand
-from django.db import connection
 
 from bluebottle.clients.models import Client
 from bluebottle.clients.utils import LocalTenant

--- a/bluebottle/recurring_donations/management/commands/process_monthly_donations.py
+++ b/bluebottle/recurring_donations/management/commands/process_monthly_donations.py
@@ -63,8 +63,6 @@ class Command(BaseCommand):
 
         try:
             client = Client.objects.get(client_name=options['tenant'])
-            connection.set_tenant(client)
-
         except Client.DoesNotExist:
             logger.error("You must specify a valid tenant with -t or --tenant.")
             tenants = Client.objects.all().values_list('client_name', flat=True)

--- a/bluebottle/recurring_donations/tasks.py
+++ b/bluebottle/recurring_donations/tasks.py
@@ -5,7 +5,6 @@ from celery import shared_task
 from collections import namedtuple
 from moneyed import Money
 
-from django.db import connection
 from django.utils.timezone import now
 from django.utils import timezone
 
@@ -41,7 +40,6 @@ def process_monthly_batch(tenant, monthly_batch, send_email):
     :param send_email: Are emails to be send or do we run this quietly.
     :return:
     """
-    connection.set_tenant(tenant)
     with LocalTenant(tenant, clear_tenant=True):
 
         if not monthly_batch:

--- a/bluebottle/surveys/management/commands/sync_surveys.py
+++ b/bluebottle/surveys/management/commands/sync_surveys.py
@@ -1,6 +1,5 @@
 from bluebottle.clients import properties
 from django.core.management.base import BaseCommand
-from django.db import connection
 
 from bluebottle.clients.models import Client
 from bluebottle.clients.utils import LocalTenant
@@ -19,7 +18,6 @@ class Command(BaseCommand):
     def sync_surveys_for_client(self, client):
         """
         """
-        connection.set_tenant(client)
         with LocalTenant(client, clear_tenant=True):
 
             if properties.SURVEYGIZMO_API_TOKEN:

--- a/bluebottle/surveys/tasks.py
+++ b/bluebottle/surveys/tasks.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 
 import logging
 
-from django.db import connection
-
 from django.core.management import call_command
 
 from celery import shared_task
@@ -23,7 +21,6 @@ def sync_surveys():
 @shared_task
 def sync_survey(client, survey):
     logger.info("Synchronzing survey (webhook)")
-    connection.set_tenant(client)
     with LocalTenant(client, clear_tenant=True):
         survey.synchronize()
     logger.info("Finished synchronizing survey")

--- a/bluebottle/tasks/taskmail.py
+++ b/bluebottle/tasks/taskmail.py
@@ -1,7 +1,6 @@
 from celery import shared_task
 
 from django.dispatch import receiver
-from django.db import connection
 from django.db.models.signals import pre_save, pre_delete, post_save
 from django.utils.translation import ugettext as _
 from django.utils.safestring import mark_safe
@@ -216,8 +215,6 @@ def send_task_realized_mail(task, template, subject, tenant):
     """ Send an email to the task owner with the request to confirm
     the task participants.
     """
-    connection.set_tenant(tenant)
-
     with LocalTenant(tenant, clear_tenant=True):
         if len(task.members.filter(status=TaskMember.TaskMemberStatuses.realized)):
             # There is already a confirmed task member: Do not bother the owner
@@ -235,8 +232,6 @@ def send_task_realized_mail(task, template, subject, tenant):
 
 @shared_task
 def send_deadline_to_apply_passed_mail(task, subject, tenant):
-    connection.set_tenant(tenant)
-
     with LocalTenant(tenant, clear_tenant=True):
         if not task.members_applied:
             template = 'deadline_to_apply_closed'


### PR DESCRIPTION
context manager.

Also set the db connection correctly. I so no usecase where we would not
want that. But it easy to forget and mess up.

Remove the duplicate calls to set_tenant everywhere.