### PR TITLE
Do not check if the task member is duplicate for existing tasks.

### DIFF
--- a/bluebottle/tasks/serializers.py
+++ b/bluebottle/tasks/serializers.py
@@ -22,28 +22,21 @@ class UniqueTaskMemberValidator(object):
         self.request = serializer.context['request']
 
     def __call__(self, data):
-        if 'task' not in data:
-            return
-
-        queryset = TaskMember.objects.filter(
-            member=self.request.user,
-            task=data['task']
-        ).exclude(
-            status__in=(
-                TaskMember.TaskMemberStatuses.rejected,
-                TaskMember.TaskMemberStatuses.withdrew
-            )
-        )
-
-        if self.instance is not None:
-            queryset = queryset.exclude(
-                pk=self.instance.pk
+        if self.instance is None:
+            queryset = TaskMember.objects.filter(
+                member=self.request.user,
+                task=data['task']
+            ).exclude(
+                status__in=(
+                    TaskMember.TaskMemberStatuses.rejected,
+                    TaskMember.TaskMemberStatuses.withdrew
+                )
             )
 
-        if queryset.exists():
-            raise ValidationError(
-                _('It is not possible to apply twice for the same task')
-            )
+            if queryset.exists():
+                raise ValidationError(
+                    _('It is not possible to apply twice for the same task')
+                )
 
 
 class BaseTaskMemberSerializer(serializers.ModelSerializer):

--- a/bluebottle/tasks/tests/test_api.py
+++ b/bluebottle/tasks/tests/test_api.py
@@ -321,6 +321,29 @@ class TaskApiTestcase(BluebottleTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+    def test_task_member_confirm_as_taskmember(self):
+        task = TaskFactory.create(
+            status=Task.TaskStatuses.open,
+            author=self.another_user,
+            project=self.some_project,
+            people_needed=1
+        )
+
+        TaskMemberFactory.create(
+            member=self.another_user, task=task, status='accepted'
+        )
+        task_member = TaskMemberFactory.create(
+            member=self.some_user, task=task, status='accepted'
+        )
+        data = {
+            'status': 'accepted',
+            'message': 'Just a test message\nWith a newline'
+        }
+
+        task_member_url = reverse('task-member-detail', kwargs={'pk': task_member.pk})
+        response = self.client.put(task_member_url, data=data, token=self.another_token)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     def test_time_spent(self):
         task = TaskFactory.create(
             status=Task.TaskStatuses.open,

--- a/bluebottle/tasks/tests/test_api.py
+++ b/bluebottle/tasks/tests/test_api.py
@@ -324,24 +324,25 @@ class TaskApiTestcase(BluebottleTestCase):
     def test_task_member_confirm_as_taskmember(self):
         task = TaskFactory.create(
             status=Task.TaskStatuses.open,
-            author=self.another_user,
+            author=self.some_user,
             project=self.some_project,
             people_needed=1
         )
 
         TaskMemberFactory.create(
-            member=self.another_user, task=task, status='accepted'
-        )
-        task_member = TaskMemberFactory.create(
             member=self.some_user, task=task, status='accepted'
         )
+        task_member = TaskMemberFactory.create(
+            member=self.another_user, task=task, status='accepted'
+        )
         data = {
-            'status': 'accepted',
+            'status': 'realized',
+            'task': task.pk,
             'message': 'Just a test message\nWith a newline'
         }
 
         task_member_url = reverse('task-member-detail', kwargs={'pk': task_member.pk})
-        response = self.client.put(task_member_url, data=data, token=self.another_token)
+        response = self.client.put(task_member_url, data=data, token=self.some_token)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_time_spent(self):


### PR DESCRIPTION
This fixes confirming task members where the task author is also a
member. In that case the check would falsely mark the member as
duplicate.

BB-11820 #resolve