### PR TITLE
Make sure taskmembers also follow the project the task belongs to.

### DIFF
--- a/bluebottle/bb_follow/models.py
+++ b/bluebottle/bb_follow/models.py
@@ -107,7 +107,6 @@ def create_follow(sender, instance, created, **kwargs):
         if user and followed_object:
 
             content_type = ContentType.objects.get_for_model(followed_object)
-
             try:
                 follow = Follow.objects.get(user=user,
                                             object_id=followed_object.id,
@@ -115,6 +114,17 @@ def create_follow(sender, instance, created, **kwargs):
             except Follow.DoesNotExist:
                 if user != followed_object.author and user != followed_object.project.owner:
                     follow = Follow(user=user, followed_object=followed_object)
+                    follow.save()
+
+            # Also follow the project
+            content_type = ContentType.objects.get_for_model(followed_object.project)
+            try:
+                follow = Follow.objects.get(user=user,
+                                            object_id=followed_object.project.id,
+                                            content_type=content_type)
+            except Follow.DoesNotExist:
+                if user != followed_object.author and user != followed_object.project.owner:
+                    follow = Follow(user=user, followed_object=followed_object.project)
                     follow.save()
 
     # A user creates a task for a project

--- a/bluebottle/bb_follow/tests/test_models.py
+++ b/bluebottle/bb_follow/tests/test_models.py
@@ -103,9 +103,12 @@ class FollowTests(BluebottleTestCase):
         self.assertEqual(Follow.objects.count(), 0)
 
         task_member_1 = TaskMemberFactory(task=self.task)
-        self.assertEqual(Follow.objects.count(), 1)
+        self.assertEqual(Follow.objects.count(), 2)
         self.assertEqual(Follow.objects.all()[0].followed_object, self.task)
         self.assertEqual(Follow.objects.all()[0].user, task_member_1.member)
+
+        self.assertEqual(Follow.objects.all()[1].followed_object, self.task.project)
+        self.assertEqual(Follow.objects.all()[1].user, task_member_1.member)
 
     def test_create_follow_create_fundraiser(self):
         """ Test that a Fundraiser also becomes a follower of a project """
@@ -295,10 +298,10 @@ class FollowTests(BluebottleTestCase):
 
         mail.outbox = []
 
-        self.assertEqual(Follow.objects.count(), 3)
+        self.assertEqual(Follow.objects.count(), 5)
         for follower in Follow.objects.all():
             if follower.user != task_owner1:
-                self.assertEqual(follower.followed_object, task)
+                self.assertTrue(follower.followed_object in (task, task.project))
 
         TextWallpostFactory.create(content_object=task,
                                    author=task_owner1,


### PR DESCRIPTION
This might not be the most natural, but several clients indicated that
not following the project was unintuitive.

BB-11903 #resolve