### PR TITLE
Make it possible to mark task members as absent

### DIFF
--- a/bluebottle/bb_tasks/templates/task_member_realized.mail.html
+++ b/bluebottle/bb_tasks/templates/task_member_realized.mail.html
@@ -8,6 +8,8 @@
         <br><br>
         You did it! The project owner {{ sender_name }} marked the task
         <i>{{ task_title }}</i> as realized. Good job!
+        <br>
+        You've spent {{ time_spent }} hours on this project.
         <br><br>
         Let's celebrate with a short comment!
     {% endblocktrans %}

--- a/bluebottle/bb_tasks/templates/task_member_realized.mail.txt
+++ b/bluebottle/bb_tasks/templates/task_member_realized.mail.txt
@@ -8,6 +8,8 @@ Hi {{ receiver_name }},
 
 You did it! The project owner {{ sender_name }} marked the task '{{ task_title }}' as realized. Good job!
 
+You've spent {{ time_spent }} hours on this project.
+
 Let's celebrate with a short comment!
 {% endblocktrans %}
 

--- a/bluebottle/tasks/models.py
+++ b/bluebottle/tasks/models.py
@@ -306,6 +306,7 @@ class TaskMember(models.Model, PreviousStatusMixin):
         stopped = ChoiceItem('stopped', label=_('Stopped'))
         withdrew = ChoiceItem('withdrew', label=_('Withdrew'))
         realized = ChoiceItem('realized', label=_('Realised'))
+        absent = ChoiceItem('absent', label=_('Absent'))
 
     member = models.ForeignKey('members.Member', related_name='%(app_label)s_%(class)s_related')
     task = models.ForeignKey('tasks.Task', related_name="members")

--- a/bluebottle/tasks/models.py
+++ b/bluebottle/tasks/models.py
@@ -374,6 +374,9 @@ class TaskMember(models.Model, PreviousStatusMixin):
                 self.task.accepting == self.task.TaskAcceptingChoices.automatic):
             self.status = self.TaskMemberStatuses.accepted
 
+        if (self.status == self.TaskMemberStatuses.absent):
+            self.time_spent = 0
+
         super(TaskMember, self).save(*args, **kwargs)
 
 

--- a/bluebottle/tasks/taskmail.py
+++ b/bluebottle/tasks/taskmail.py
@@ -97,6 +97,7 @@ class TaskMemberRealizedMail(TaskMemberMailSender):
 
         survey_url = Survey.url(self.task)
         self.ctx['survey_link'] = mark_safe(survey_url) if survey_url else None
+        self.ctx['time_spent'] = self.task_member.time_spent
 
     @property
     def subject(self):
@@ -133,6 +134,7 @@ class TaskMemberMailAdapter:
         TaskMember.TaskMemberStatuses.rejected: TaskMemberRejectMail,
         TaskMember.TaskMemberStatuses.accepted: TaskMemberAcceptedMail,
         TaskMember.TaskMemberStatuses.realized: TaskMemberRealizedMail,
+        TaskMember.TaskMemberStatuses.absent: TaskMemberRealizedMail,
         TaskMember.TaskMemberStatuses.withdrew: TaskMemberWithdrawMail,
     }
 

--- a/bluebottle/tasks/tests/test_mails.py
+++ b/bluebottle/tasks/tests/test_mails.py
@@ -137,7 +137,8 @@ class TestTaskMemberMail(TaskMailTestBase):
     def test_member_realized_mail(self):
         task_member = TaskMemberFactory.create(
             task=self.task,
-            status='accepted'
+            status='accepted',
+            time_spent=8
         )
 
         task_member.status = 'realized'
@@ -148,6 +149,7 @@ class TestTaskMemberMail(TaskMailTestBase):
         email = mail.outbox[-1]
 
         self.assertNotEquals(email.subject.find("realised"), -1)
+        self.assertTrue('spent {} hours'.format(task_member.time_spent) in email.body)
         self.assertEquals(email.to[0], task_member.member.email)
 
     def test_member_realized_mail_with_survey(self):

--- a/bluebottle/tasks/tests/test_unit.py
+++ b/bluebottle/tasks/tests/test_unit.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 from django.test.utils import override_settings
 
 from bluebottle.bb_projects.models import ProjectPhase
-from bluebottle.tasks.models import Task
+from bluebottle.tasks.models import Task, TaskMember
 from bluebottle.test.factory_models.tasks import TaskFactory, TaskMemberFactory
 from bluebottle.test.factory_models.projects import ProjectFactory
 from bluebottle.test.utils import BluebottleTestCase
@@ -79,3 +79,19 @@ class TestTaskRealised(TaskUnitTestBase):
 
         self.assertEqual(self.task.status, Task.TaskStatuses.realized)
         self.assertEqual(self.project.status.slug, 'done-complete')
+
+
+class TestAbsent(TaskUnitTestBase):
+    """
+    Test what happens when a task reaches it's deadline
+    """
+    def test_all_tasks_realised_closed_project(self):
+        member = TaskMemberFactory.create(
+            task=self.task, status='accepted', time_spent=4
+        )
+        member.status = TaskMember.TaskMemberStatuses.absent
+        member.save()
+
+        self.assertEqual(member.time_spent, 0)
+
+

--- a/bluebottle/tasks/tests/test_unit.py
+++ b/bluebottle/tasks/tests/test_unit.py
@@ -93,5 +93,3 @@ class TestAbsent(TaskUnitTestBase):
         member.save()
 
         self.assertEqual(member.time_spent, 0)
-
-


### PR DESCRIPTION
Marking a task member as absent, sets it's hours to 0. A normal task
realized mail will be sent.
Add the number of hours in the email.

BB-11590 #reslove
BB-11922 #reslove