### PR TITLE
Change how we load tenant properties

### DIFF
--- a/bluebottle/clients/utils.py
+++ b/bluebottle/clients/utils.py
@@ -14,7 +14,6 @@ from django.utils.translation import get_language
 from djmoney_rates.utils import get_rate
 from djmoney_rates.exceptions import CurrencyConversionException
 from bluebottle.clients import properties
-from tenant_extras.utils import get_tenant_properties
 
 
 import logging
@@ -78,7 +77,8 @@ def get_min_amounts(methods):
 
 
 def get_currencies():
-    properties = get_tenant_properties()
+
+    properties.set_tenant(connection.tenant)
 
     currencies = set(itertools.chain(*[
         method['currencies'].keys() for method in properties.PAYMENT_METHODS
@@ -193,9 +193,8 @@ def get_public_properties(request):
 
     config = {}
 
-    properties = get_tenant_properties()
-
     props = None
+    properties.set_tenant(connection.tenant)
 
     try:
         props = getattr(properties, 'EXPOSED_TENANT_PROPERTIES')
@@ -212,7 +211,7 @@ def get_public_properties(request):
     if connection.tenant:
 
         current_tenant = connection.tenant
-        properties = get_tenant_properties()
+        properties.set_tenant(connection.tenant)
 
         config = {
             'mediaUrl': getattr(properties, 'MEDIA_URL'),

--- a/bluebottle/utils/permissions.py
+++ b/bluebottle/utils/permissions.py
@@ -1,8 +1,9 @@
 import logging
 
+from django.db import connection
 from rest_framework import permissions
 
-from tenant_extras.utils import get_tenant_properties
+from bluebottle.clients import properties
 
 logger = logging.getLogger(__name__)
 
@@ -149,16 +150,18 @@ class TenantConditionalOpenClose(BasePermission):
     """ Allows access only to authenticated users. """
 
     def has_object_action_permission(self, action, user, obj):
+        properties.set_tenant(connection.tenant)
         try:
-            if get_tenant_properties('CLOSED_SITE'):
+            if properties.CLOSED_SITE:
                 return user and user.is_authenticated()
         except AttributeError:
             pass
         return True
 
     def has_action_permission(self, action, user, model_cls):
+        properties.set_tenant(connection.tenant)
         try:
-            if get_tenant_properties('CLOSED_SITE'):
+            if properties.CLOSED_SITE:
                 return user and user.is_authenticated()
         except AttributeError:
             pass


### PR DESCRIPTION
More consistent and that it works on localhost too.
Not sure why we were using `get_tenant_properties`, which did not work for me locally. I guess it's legacy, but please tell me if I'm missing something @eodolphi :-)