### PR TITLE
Make sure that we catch exceptions when updating statuses in cron

### DIFF
--- a/bluebottle/projects/management/commands/cron_status_realised.py
+++ b/bluebottle/projects/management/commands/cron_status_realised.py
@@ -104,7 +104,6 @@ class Command(BaseCommand):
                 except Exception, e:
                     logger.error(e)
 
-
             self.stdout.write(
                 "Successfully updated the status of expired projects and Tasks")
 
@@ -120,6 +119,5 @@ class Command(BaseCommand):
                     project.save()
                 except Exception, e:
                     logger.error(e)
-
 
             self.stdout.write("Done checking projects with voting deadlines")


### PR DESCRIPTION
deadline reached.

Without this, we will not continue with the command if somethign fails, and other tenants
will not be updated.