### PR TITLE
Do not call status_changed for every task member that is changed.

### DIFF
--- a/bluebottle/tasks/signals.py
+++ b/bluebottle/tasks/signals.py
@@ -20,6 +20,8 @@ def task_post_save(sender, instance, **kwargs):
     except AttributeError:
         pass
 
+    instance._init_status = instance.status
+
 
 @receiver(pre_save, weak=False, sender=TaskMember,
           dispatch_uid='set-hours-spent-taskmember')


### PR DESCRIPTION
We did not update task._init_status, which made the call to
send_realized_mail happen for every updated taskmember within a request.

This fixes this. This does however not fix the race condition when
updating multiple task members in the frontend.