### PR TITLE
Fix privilige escalation in backoffice

### DIFF
--- a/bluebottle/members/admin.py
+++ b/bluebottle/members/admin.py
@@ -1,3 +1,4 @@
+import functools
 import six
 from adminfilters.multiselect import UnionFieldListFilter
 from adminsortable.admin import SortableTabularInline, NonSortableParentAdmin
@@ -35,7 +36,33 @@ from bluebottle.utils.widgets import SecureAdminURLFieldWidget
 from .models import Member
 
 
-class MemberCreationForm(forms.ModelForm):
+class MemberForm(forms.ModelForm):
+    def __init__(self, data=None, files=None, current_user=None, *args, **kwargs):
+        self.current_user = current_user
+        super(MemberForm, self).__init__(data, files, *args, **kwargs)
+
+        if self.current_user.is_superuser:
+            # Super users can assign every group to a user
+            group_queryset = Group.objects.all()
+        else:
+            # Normal staff users can only choose groups that they belong to.
+            group_queryset = Group.objects.filter(
+                pk__in=self.current_user.groups.all().only('pk')
+            )
+
+        self.fields['groups'] = forms.ModelMultipleChoiceField(
+            queryset=group_queryset,
+            required=False,
+            initial=Group.objects.filter(name='Authenticated')
+        )
+
+    class Meta:
+        model = Member
+        # Mind you these fields are also set in MemberAdmin.add_fieldsets
+        fields = '__all__'
+
+
+class MemberCreationForm(MemberForm):
     """
     A form that creates a member.
     """
@@ -46,17 +73,6 @@ class MemberCreationForm(forms.ModelForm):
                              help_text=_("A valid, unique email address."))
 
     is_active = forms.BooleanField(label=_("Is active"), initial=True)
-
-    def __init__(self, *args, **kwargs):
-        super(MemberCreationForm, self).__init__(*args, **kwargs)
-        authenticated = Group.objects.get(name='Authenticated')
-        self.initial['groups'] = [authenticated]
-
-    class Meta:
-        model = Member
-        # Mind you these fields are also set in MemberAdmin.add_fieldsets
-        fields = ('first_name', 'last_name', 'email',
-                  'is_active', 'is_staff', 'is_superuser', 'groups')
 
     def clean_email(self):
         # Since BlueBottleUser.email is unique, this check is redundant
@@ -102,7 +118,7 @@ class CustomAdminFormMetaClass(ModelFormMetaclass):
         return super(CustomAdminFormMetaClass, cls).__new__(cls, name, bases, attrs)
 
 
-class MemberChangeForm(six.with_metaclass(CustomAdminFormMetaClass, forms.ModelForm)):
+class MemberChangeForm(six.with_metaclass(CustomAdminFormMetaClass, MemberForm)):
     """
     Change Member form
     """
@@ -161,79 +177,102 @@ class MemberAdmin(UserAdmin):
         models.URLField: {'widget': SecureAdminURLFieldWidget()},
     }
 
-    @property
-    def standard_fieldsets(self):
+    def get_form(self, request, *args, **kwargs):
+        Form = super(MemberAdmin, self).get_form(request, *args, **kwargs)
+        return functools.partial(Form, current_user=request.user)
 
-        standard_fieldsets = [
-            [_("Main"), {'fields': [
-                'remote_id',
-                'email',
-                'first_name',
-                'last_name',
-                'username',
-                'phone_number',
-                'reset_password',
-                'resend_welcome_link',
-                'last_login',
-                'date_joined',
-                'deleted',
-                'is_co_financer',
-                'can_pledge',
-                'partner_organization',
-                'campaign_notifications',
-                'newsletter',
-                'primary_language',
-            ]}],
-            [_("Profile"),
-             {'fields': [
-                 'picture',
-                 'about_me',
-                 'favourite_themes',
-                 'skills'
-             ]}],
-            [_('Engagement'),
-             {'fields': [
-                 'projects_managed',
-                 'tasks',
-                 'donations',
-                 'following'
-             ]}],
+    def get_fieldsets(self, request, obj=None):
+        if not obj:
+            fieldsets = ((
+                None, {
+                    'classes': ('wide', ),
+                    'fields': [
+                        'first_name', 'last_name', 'email', 'is_active',
+                        'is_staff', 'groups'
+                    ]
+                }
+            ), )
+        else:
+            fieldsets = [
+                [
+                    _("Main"),
+                    {
+                        'fields': [
+                            'email',
+                            'remote_id',
+                            'first_name',
+                            'last_name',
+                            'phone_number',
+                            'reset_password',
+                            'resend_welcome_link',
+                            'last_login',
+                            'date_joined',
+                            'deleted',
+                            'is_co_financer',
+                            'can_pledge',
+                            'partner_organization',
+                            'campaign_notifications',
+                            'newsletter',
+                            'primary_language',
+                        ]
+                    }
+                ],
+                [
+                    _("Profile"),
+                    {
+                        'fields':
+                        ['picture', 'about_me', 'favourite_themes', 'skills']
+                    }
+                ],
+                [
+                    _('Permissions'),
+                    {'fields': ['is_active', 'is_staff', 'is_superuser', 'groups']}
+                ],
+                [
+                    _('Engagement'),
+                    {
+                        'fields':
+                        ['projects_managed', 'tasks', 'donations', 'following']
+                    }
+                ],
+            ]
+
+            if Location.objects.count():
+                fieldsets[1][1]['fields'].append('location')
+
+            if 'Pledge' not in (
+                item['name'] for item in properties.PAYMENT_METHODS
+            ):
+                fieldsets[0][1]['fields'].remove('can_pledge')
+
+            if CustomMemberFieldSettings.objects.count():
+                extra = (
+                    _('Extra fields'), {
+                        'fields': [
+                            field.slug
+                            for field in CustomMemberFieldSettings.objects.all()
+                        ]
+                    }
+                )
+
+                fieldsets.append(extra)
+
+        return fieldsets
+
+    def get_readonly_fields(self, request, obj=None):
+        readonly_fields = [
+            'date_joined', 'last_login',
+            'updated', 'deleted', 'login_as_user',
+            'reset_password', 'resend_welcome_link',
+            'projects_managed', 'tasks', 'donations', 'following'
         ]
+        if obj and obj.is_staff and not request.user.is_superuser:
+            readonly_fields.append('email')
 
-        if Location.objects.count():
-            standard_fieldsets[1][1]['fields'].append('location')
+        if not request.user.is_superuser:
+            readonly_fields.append('is_superuser')
 
-        if 'Pledge' not in (item['name'] for item in properties.PAYMENT_METHODS):
-            standard_fieldsets[0][1]['fields'].remove('can_pledge')
-
-        if CustomMemberFieldSettings.objects.count():
-            extra = (_('Extra fields'), {
-                'fields': [field.slug for field in CustomMemberFieldSettings.objects.all()]
-            })
-
-            standard_fieldsets.append(extra)
-
-        return tuple(standard_fieldsets)
-
-    staff_fieldsets = (
-        (_('Permissions'), {'fields': ('is_active', 'is_staff', 'can_pledge', 'groups')}),
-    )
-
-    superuser_fieldsets = (
-        (_('Permissions'), {'fields': ('is_active', 'is_staff', 'is_superuser', 'can_pledge', 'groups')}),
-    )
-
-    add_fieldsets = (
-        (None, {'classes': ('wide',),
-                'fields': ('first_name', 'last_name', 'email',
-                           'is_active', 'is_staff', 'is_superuser', 'groups')}
-         ),
-    )
-
-    readonly_fields = ('date_joined', 'last_login',
-                       'updated', 'deleted', 'login_as_user',
-                       'reset_password', 'resend_welcome_link',
-                       'projects_managed', 'tasks', 'donations', 'following')
+        return readonly_fields
 
     export_fields = (
         ('username', 'username'),
@@ -328,13 +367,11 @@ class MemberAdmin(UserAdmin):
     following.short_description = _('Following')
 
     def reset_password(self, obj):
-        reset_form_url = reverse('admin:auth_user_password_change', args=(obj.id, ))
         reset_mail_url = reverse('admin:auth_user_password_reset_mail', kwargs={'user_id': obj.id})
         properties.set_tenant(connection.tenant)
 
         return format_html(
-            "<a href='{}'>{}</a>  | <a href='{}'>{}</a>",
-            reset_form_url, _("Reset password form"),
+            "<a href='{}'>{}</a>",
             reset_mail_url, _("Send reset password mail")
         )
 
@@ -351,28 +388,6 @@ class MemberAdmin(UserAdmin):
             obj.id,
             _('Login as user')
         )
-
-    def change_view(self, request, *args, **kwargs):
-        # for superuser
-        try:
-            if request.user.is_superuser:
-                self.fieldsets = self.standard_fieldsets + self.superuser_fieldsets
-            else:
-                self.fieldsets = self.standard_fieldsets + self.staff_fieldsets
-
-            response = UserAdmin.change_view(self, request, *args, **kwargs)
-        finally:
-            # Reset fieldsets to its original value
-            self.fieldsets = self.standard_fieldsets
-
-        return response
-
-    def __init__(self, *args, **kwargs):
-        super(MemberAdmin, self).__init__(*args, **kwargs)
-
-        self.list_display = (
-            'email', 'first_name', 'last_name', 'is_staff', 'date_joined',
-            'is_active', 'login_as_link')
 
     def get_inline_instances(self, request, obj=None):
         """ Override get_inline_instances so that the add form does not show inlines """

--- a/bluebottle/members/tests/test_admin.py
+++ b/bluebottle/members/tests/test_admin.py
@@ -2,14 +2,16 @@
 import os
 
 from django.contrib.admin.sites import AdminSite
+from django.contrib.auth.models import Group
 from django.core import mail
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.conf import settings
+from django.utils import timezone
 
 from tenant_schemas.urlresolvers import reverse
 
-from bluebottle.members.admin import MemberAdmin, MemberChangeForm
+from bluebottle.members.admin import MemberAdmin, MemberChangeForm, MemberCreationForm
 from bluebottle.members.models import CustomMemberFieldSettings, Member, CustomMemberField
 from bluebottle.test.factory_models.accounts import BlueBottleUserFactory
 from bluebottle.test.utils import BluebottleAdminTestCase, BluebottleTestCase
@@ -23,8 +25,9 @@ class MockRequest:
 
 
 class MockUser:
-    def __init__(self, perms=None, is_staff=True):
+    def __init__(self, perms=None, is_staff=True, is_superuser=False):
         self.perms = perms or []
+        self.is_superuser = is_superuser
         self.is_staff = is_staff
 
 
@@ -87,7 +90,6 @@ class MemberAdminTest(BluebottleAdminTestCase):
         response = self.client.get(member_url)
         self.assertEquals(response.status_code, 200)
         self.assertContains(response, 'Send reset password mail')
-        self.assertContains(response, 'Reset password form')
 
         # Assert password reset link sends the right email
         reset_url = reverse('admin:auth_user_password_reset_mail', kwargs={'user_id': user.id})
@@ -154,13 +156,117 @@ class MemberCustomFieldAdminTest(BluebottleAdminTestCase):
 
     def test_save_custom_fields(self):
         member = BlueBottleUserFactory.create()
+        staff = BlueBottleUserFactory.create(is_staff=True)
         CustomMemberFieldSettings.objects.create(name='Department')
         data = member.__dict__
         data['department'] = 'Engineering'
-        form = MemberChangeForm(instance=member, data=data)
+        form = MemberChangeForm(current_user=staff, instance=member, data=data)
         form.save()
         member.refresh_from_db()
         self.assertEqual(member.extra.get().value, 'Engineering')
+
+
+class MemberFormAdminTest(BluebottleAdminTestCase):
+    """
+    Test extra fields in Member Admin
+    """
+
+    def setUp(self):
+        super(MemberFormAdminTest, self).setUp()
+        self.client.force_login(self.superuser)
+        self.staff = BlueBottleUserFactory.create(is_staff=True)
+
+    def test_save(self):
+        data = {
+            'email': 'bla@example.com',
+            'first_name': 'bla',
+            'last_name': 'Example',
+            'is_active': True,
+            'username': 'bla@example.com',
+            'password': 'bla',
+            'primary_language': 'en',
+            'user_type': 'person',
+            'date_joined': timezone.now(),
+            'groups': [self.staff.groups.get().pk]
+        }
+        form = MemberCreationForm(current_user=self.staff, data=data)
+        form.save()
+
+        member = Member.objects.get(email='bla@example.com')
+        self.assertTrue(member.first_name, 'bla')
+        self.assertTrue(member.groups.get().pk, self.staff.groups.get().pk)
+
+    def test_groups_not_required(self):
+        data = {
+            'email': 'bla@example.com',
+            'first_name': 'bla',
+            'last_name': 'Example',
+            'is_active': True,
+            'username': 'bla@example.com',
+            'password': 'bla',
+            'primary_language': 'en',
+            'user_type': 'person',
+            'date_joined': timezone.now(),
+        }
+        form = MemberCreationForm(current_user=self.staff, data=data)
+        form.save()
+
+        member = Member.objects.get(email='bla@example.com')
+        self.assertTrue(member.first_name, 'bla')
+        self.assertTrue(len(member.groups.all()), 0)
+
+    def test_user_not_part_of_gruop(self):
+        group, _ = Group.objects.get_or_create(name='New group')
+        data = {
+            'email': 'bla@example.com',
+            'first_name': 'bla',
+            'last_name': 'Example',
+            'is_active': True,
+            'username': 'bla@example.com',
+            'password': 'bla',
+            'primary_language': 'en',
+            'user_type': 'person',
+            'date_joined': timezone.now(),
+            'groups': [group.pk]
+        }
+        form = MemberCreationForm(current_user=self.staff, data=data)
+        self.assertTrue('groups' in form.errors)
+
+
+class MemberAdminFieldsTest(BluebottleTestCase):
+    def setUp(self):
+        super(MemberAdminFieldsTest, self).setUp()
+        self.request = RequestFactory().get('/')
+        self.request.user = MockUser()
+
+        self.member = BlueBottleUserFactory.create()
+        self.member_admin = MemberAdmin(Member, AdminSite())
+
+    def test_readonlyfiels(self):
+        fields = self.member_admin.get_readonly_fields(self.request, self.member)
+        expected_fields = set((
+            'date_joined', 'last_login', 'updated', 'deleted', 'login_as_user',
+            'reset_password', 'resend_welcome_link', 'projects_managed', 'tasks',
+            'donations', 'following', 'is_superuser'
+        ))
+
+        self.assertEqual(expected_fields, set(fields))
+
+    def test_staff_email(self):
+        self.member.is_staff = True
+        fields = self.member_admin.get_readonly_fields(self.request, self.member)
+        self.assertTrue('email' in fields)
+
+    def test_staff_email_superuser(self):
+        self.request.user.is_superuser = True
+        self.member.is_staff = True
+        fields = self.member_admin.get_readonly_fields(self.request, self.member)
+        self.assertTrue('email' not in fields)
+
+    def test_super_user(self):
+        self.request.user.is_superuser = True
+        fields = self.member_admin.get_readonly_fields(self.request, self.member)
+        self.assertTrue('is_superuser' not in fields)
 
 
 class MemberAdminExportTest(BluebottleTestCase):


### PR DESCRIPTION
Non-super users can no longer assign groups to user that they are not
part of themselves.
Non-super users can no longer change the email of other staff users.
It is no longer possible to directly set the password of users.