### PR TITLE
Do not show bootstrap interface for drf api. Do not use cdn for files we

### DIFF
--- a/bluebottle/settings/base.py
+++ b/bluebottle/settings/base.py
@@ -167,6 +167,9 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.TokenAuthentication'
     ),
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+    ),
     'DEFAULT_PERMISSION_CLASSES': (
         'bluebottle.utils.permissions.TenantConditionalOpenClose',
     ),
@@ -866,6 +869,10 @@ TASKS = {
 
 ENABLE_REFUNDS = False
 
+
+def static_url(url):
+    return os.path.join(STATIC_URL, url)
+
 SUMMERNOTE_CONFIG = {
     # Using SummernoteWidget - iframe mode
     'toolbar': [
@@ -880,7 +887,22 @@ SUMMERNOTE_CONFIG = {
     'attachment_upload_to': 'project_images/',
     'summernote': {
         'disableResizeImage': True
-    }
+    },
+    'default_css': (
+        static_url('rest_framework/css/bootstrap.min.css'),
+        static_url('django_summernote/summernote.css'),
+        static_url('django_summernote/django_summernote.css'),
+    ),
+    'default_js': (
+        static_url('admin/js/vendor/jquery/jquery.min.js'),
+        static_url('rest_framework/js/bootstrap.min.js'),
+        static_url('django_summernote/jquery.ui.widget.js'),
+        static_url('django_summernote/jquery.iframe-transport.js'),
+        static_url('django_summernote/jquery.fileupload.js'),
+        static_url('django_summernote/summernote.min.js'),
+        static_url('django_summernote/ResizeSensor.js'),
+    ),
+
 }
 
 HOMEPAGE = {}


### PR DESCRIPTION
host ourselves.

The bootstrap version bundled with drf has a security issue that takes
forever to be fixed. For now we disable the styled interface completely.

Summernote loads some files over a cdn by default, since we also host
these files, we might aswell use those. This way we also do not need to
worry about the security implications.