### PR TITLE
Do not remove popularity field from db for now.

### DIFF
--- a/bluebottle/projects/migrations/0080_auto_20180828_1049.py
+++ b/bluebottle/projects/migrations/0080_auto_20180828_1049.py
@@ -14,10 +14,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RemoveField(
-            model_name='project',
-            name='popularity',
-        ),
         migrations.AlterField(
             model_name='project',
             name='location',

--- a/bluebottle/projects/migrations/0080_auto_20180828_1049.py
+++ b/bluebottle/projects/migrations/0080_auto_20180828_1049.py
@@ -16,6 +16,11 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AlterField(
             model_name='project',
+            name='popularity',
+            field=models.FloatField(null=True),
+        ),
+        migrations.AlterField(
+            model_name='project',
             name='location',
             field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='geo.Location'),
         ),


### PR DESCRIPTION
This will break the old code running against the migrated db, resulting
in downtime during the release.

We should remove this field when the changes are deployed.