### PR TITLE
Do not add a slash to the url. Ember does not like slashes after the id,

### DIFF
--- a/bluebottle/cms/urls/api.py
+++ b/bluebottle/cms/urls/api.py
@@ -6,7 +6,7 @@ from bluebottle.cms.views import (
 
 urlpatterns = [
     url(r'^results/(?P<pk>\d+)$', ResultPageDetail.as_view(), name='result-page-detail'),
-    url(r'^homepage/$', HomePageDetail.as_view(), {'pk': 1}, name='home-page-detail'),
+    url(r'^homepage$', HomePageDetail.as_view(), {'pk': 1}, name='home-page-detail'),
     url(r'^news-item/(?P<slug>[\w-]+)$', NewsItemDetail.as_view(), name='news-item-detail'),
     url(r'^page/(?P<slug>[\w-]+)$', PageDetail.as_view(), name='page-detail'),
 ]


### PR DESCRIPTION
and we (incorrectly) use 'homepage' as the id.