### PR TITLE
Small fixes for the stripe adapter:

### DIFF
--- a/bluebottle/payments_stripe/tests/test_adapters.py
+++ b/bluebottle/payments_stripe/tests/test_adapters.py
@@ -11,6 +11,7 @@ from bluebottle.test.factory_models.payouts import StripePayoutAccountFactory
 from bluebottle.test.factory_models.projects import ProjectFactory
 from bluebottle.test.utils import BluebottleTestCase
 
+from bluebottle.payments.exception import PaymentException
 from bluebottle.payments_stripe.adapters import StripePaymentAdapter
 
 
@@ -113,10 +114,34 @@ class StripePaymentAdapterTestCase(BluebottleTestCase):
                 self.assertEqual(call_args['metadata']['project_slug'], self.project.slug)
                 self.assertEqual(call_args['metadata']['project_title'], self.project.title)
 
-    def test_check_payment_status(self):
+    def test_payment_charged_card_error(self):
         adapter = StripePaymentAdapter(self.order_payment)
-        adapter.check_payment_status()
-        self.assertEqual(adapter.payment.status, 'started')
+        with patch(
+            'stripe.Charge.create',
+            side_effect=stripe.error.CardError('Invalid card', 'api_error', 402)
+        ) as create:
+            adapter.charge()
+            self.assertTrue(adapter.payment.pk)
+            self.assertEqual(adapter.payment.status, 'failed')
+
+    def test_payment_charged_connection_error(self):
+        adapter = StripePaymentAdapter(self.order_payment)
+        with patch(
+            'stripe.Charge.create',
+            side_effect=stripe.error.APIConnectionError('Could not connect')
+        ) as create:
+            self.assertRaises(
+                PaymentException,
+                adapter.charge
+            )
+
+    def test_check_payment_status(self):
+        source = stripe.Source('some source token')
+        adapter = StripePaymentAdapter(self.order_payment)
+
+        with patch('stripe.Source.retrieve', return_value=source):
+            adapter.check_payment_status()
+            self.assertEqual(adapter.payment.status, 'started')
 
     def test_check_payment_status_charged(self):
         charge = stripe.Charge('some charge token')
@@ -216,6 +241,18 @@ class StripePaymentAdapterTestCase(BluebottleTestCase):
                 adapter.check_payment_status()
                 self.assertTrue(adapter.payment.pk)
                 self.assertEqual(adapter.payment.status, 'charged_back')
+
+    def test_check_payment_status_no_charge(self):
+        source = stripe.Source('some source token')
+        source.update({
+            'consumed': True
+        })
+
+        adapter = StripePaymentAdapter(self.order_payment)
+        with patch('stripe.Source.retrieve', return_value=source):
+            adapter.check_payment_status()
+            self.assertTrue(adapter.payment.pk)
+            self.assertEqual(adapter.payment.status, 'failed')
 
     def test_refund(self):
         adapter = StripePaymentAdapter(self.order_payment)

--- a/bluebottle/payments_stripe/tests/test_adapters.py
+++ b/bluebottle/payments_stripe/tests/test_adapters.py
@@ -119,7 +119,7 @@ class StripePaymentAdapterTestCase(BluebottleTestCase):
         with patch(
             'stripe.Charge.create',
             side_effect=stripe.error.CardError('Invalid card', 'api_error', 402)
-        ) as create:
+        ):
             adapter.charge()
             self.assertTrue(adapter.payment.pk)
             self.assertEqual(adapter.payment.status, 'failed')
@@ -129,7 +129,7 @@ class StripePaymentAdapterTestCase(BluebottleTestCase):
         with patch(
             'stripe.Charge.create',
             side_effect=stripe.error.APIConnectionError('Could not connect')
-        ) as create:
+        ):
             self.assertRaises(
                 PaymentException,
                 adapter.charge

--- a/bluebottle/payments_stripe/tests/test_webhooks.py
+++ b/bluebottle/payments_stripe/tests/test_webhooks.py
@@ -189,8 +189,8 @@ class StripePaymentAdapterTestCase(BluebottleTestCase):
             with patch(
                 'stripe.Charge.create',
                 side_effect=stripe.error.CardError('The source could not be charged', 'api_error', 400)
-            ) as charge:
-                response = self.client.post(
+            ):
+                self.client.post(
                     reverse('stripe-webhook'),
                     HTTP_STRIPE_SIGNATURE='some signature'
                 )

--- a/bluebottle/payments_stripe/tests/test_webhooks.py
+++ b/bluebottle/payments_stripe/tests/test_webhooks.py
@@ -4,8 +4,10 @@ import stripe
 from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
 
+from bluebottle.test.factory_models.donations import DonationFactory
 from bluebottle.test.factory_models.payments import OrderPaymentFactory
 from bluebottle.test.factory_models.payments_stripe import StripePaymentFactory
+from bluebottle.test.factory_models.payouts import StripePayoutAccountFactory
 from bluebottle.test.utils import BluebottleTestCase
 
 
@@ -53,6 +55,9 @@ class StripePaymentAdapterTestCase(BluebottleTestCase):
             source_token=source_token,
             order_payment=order_payment
         )
+        donation = DonationFactory.create(order=order_payment.order)
+        donation.project.payout_account = StripePayoutAccountFactory.create()
+        donation.project.save()
 
         class MockEvent(object):
             def __init__(self, type, object):
@@ -170,3 +175,24 @@ class StripePaymentAdapterTestCase(BluebottleTestCase):
                 HTTP_STRIPE_SIGNATURE='some signature'
             )
             self.assertEqual(response.status_code, 400)
+
+    def test_chargeable_error(self):
+        self.payment.charge_token = None
+        self.payment.save()
+
+        with patch(
+            'stripe.Webhook.construct_event',
+            return_value=self.MockEvent(
+                'source.chargeable', {'id': self.payment.source_token}
+            )
+        ):
+            with patch(
+                'stripe.Charge.create',
+                side_effect=stripe.error.CardError('The source could not be charged', 'api_error', 400)
+            ) as charge:
+                response = self.client.post(
+                    reverse('stripe-webhook'),
+                    HTTP_STRIPE_SIGNATURE='some signature'
+                )
+                self.payment.refresh_from_db()
+                self.assertEqual(self.payment.status, 'failed')

--- a/bluebottle/payments_stripe/views.py
+++ b/bluebottle/payments_stripe/views.py
@@ -25,11 +25,10 @@ class WebHookView(View):
 
             if event.type == 'source.chargeable':
                 payment = StripePayment.objects.get(source_token=event.data.object.id)
-                payment.status = 'authorized'
-                payment.save()
 
                 service = PaymentService(payment.order_payment)
                 service.adapter.charge()
+
             elif event.type == 'charge.dispute.closed' and event.data.object.status == 'lost':
                 payment = StripePayment.objects.get(charge_token=event.data.object.charge)
                 service = PaymentService(payment.order_payment)


### PR DESCRIPTION
When a charge fails, handle this correctly. This will make sure we mark
failed credit card donations correctly as charged.

When a source has no charge but is marked as consumed, mark it as
failed.