### PR TITLE
Also send a mail to the object's owner when a MediaWallpost is created.

### DIFF
--- a/bluebottle/wallposts/mails.py
+++ b/bluebottle/wallposts/mails.py
@@ -41,15 +41,16 @@ import logging
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from bluebottle.wallposts.models import Reaction, TextWallpost
+from bluebottle.wallposts.models import Reaction, TextWallpost, MediaWallpost
 from bluebottle.wallposts.notifiers import ObserversContainer
 
 logger = logging.getLogger(__name__)
 
 
 @receiver(post_save, weak=False, sender=TextWallpost)
+@receiver(post_save, weak=False, sender=MediaWallpost)
 def new_wallpost_notification(sender, instance, created, **kwargs):
-    if created:
+    if created and not instance.donation:
         container = ObserversContainer()
         container.notify_wallpost_observers(instance)
 

--- a/bluebottle/wallposts/tests/test_api.py
+++ b/bluebottle/wallposts/tests/test_api.py
@@ -520,6 +520,40 @@ class WallpostMailTests(UserTestsMixin, BluebottleTestCase):
         self.assertEqual(m.to, [self.user_a.email])
         self.assertEqual(m.activated_language, self.user_a.primary_language)
 
+    def test_new_wallpost_with_donation_by_b_on_project_by_a(self):
+        """
+        Project by A + Wallpost by B => Mail to (project owner) A
+        """
+        # Object by A
+        # |
+        # +-- Wallpost by B (+)
+
+        TextWallpostFactory.create(
+            content_object=self.project_1,
+            donation=DonationFactory.create(),
+            author=self.user_b
+        )
+
+        # Mailbox should NOT contain an email to project owner.
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_new_media_wallpost_by_b_on_project_by_a(self):
+        """
+        Project by A + Wallpost by B => Mail to (project owner) A
+        """
+        # Object by A
+        # |
+        # +-- Wallpost by B (+)
+
+        MediaWallpostFactory.create(content_object=self.project_1, author=self.user_b)
+
+        # Mailbox should contain an email to project owner.
+        self.assertEqual(len(mail.outbox), 1)
+        m = mail.outbox[0]
+
+        self.assertEqual(m.to, [self.user_a.email])
+        self.assertEqual(m.activated_language, self.user_a.primary_language)
+
     def test_delete_wallpost_by_b_on_project_by_a(self):
         """
         Project by A + Wallpost by B => Mail to (project owner) A


### PR DESCRIPTION
Make sure we do not send the message when a donation is attached.

BB-14343 #resolve