### PR TITLE
Require organization when settings is set to true.

### DIFF
--- a/bluebottle/initiatives/models.py
+++ b/bluebottle/initiatives/models.py
@@ -126,6 +126,12 @@ class Initiative(TransitionsMixin, models.Model):
         if not self.activity_manager:
             self.activity_manager = self.owner
 
+        try:
+            if InitiativePlatformSettings.objects.get().require_organization:
+                self.has_organization = True
+        except InitiativePlatformSettings.DoesNotExist:
+            pass
+
         if self.has_organization and not self.organization and self.owner and self.owner.partner_organization:
             self.organization = self.owner.partner_organization
 

--- a/bluebottle/initiatives/serializers.py
+++ b/bluebottle/initiatives/serializers.py
@@ -132,6 +132,39 @@ def _error_messages_for(label):
     }
 
 
+class OrganizationSubmitSerializer(serializers.ModelSerializer):
+    name = serializers.CharField(required=True, error_messages={'blank': _('Name is required')})
+
+    def __init__(self, *args, **kwargs):
+        super(OrganizationSubmitSerializer, self).__init__(*args, **kwargs)
+
+    def validate_empty_values(self, data):
+        if self.parent.initial_data['has_organization'] and not data:
+            return (False, data)
+        else:
+            return (False if data else True, data)
+
+    class Meta:
+        model = Organization
+        fields = ('name', )
+
+
+class OrganizationContactSubmitSerializer(serializers.ModelSerializer):
+    name = serializers.CharField(required=True, error_messages={'blank': _('Name is required')})
+    email = serializers.CharField(required=True, error_messages={'blank': _('Email is required')})
+    phone = serializers.CharField(required=True, error_messages={'blank': _('Phone is required')})
+
+    def validate_empty_values(self, data):
+        if self.parent.initial_data['has_organization'] and not data:
+            return (False, data)
+        else:
+            return (False if data else True, data)
+
+    class Meta:
+        model = OrganizationContact
+        fields = ('name', 'email', 'phone', )
+
+
 class InitiativeSubmitSerializer(ModelSerializer):
     title = serializers.CharField(required=True, error_messages={'blank': _('Title is required')})
     pitch = serializers.CharField(required=True, error_messages={'blank': _('Pitch is required')})
@@ -156,12 +189,10 @@ class InitiativeSubmitSerializer(ModelSerializer):
         required=True, queryset=Geolocation.objects.all(),
         error_messages={'null': _('Place is required')}
     )
-    organization = serializers.PrimaryKeyRelatedField(
-        allow_null=True, queryset=Organization.objects.all(),
+    organization = OrganizationSubmitSerializer(
         error_messages={'null': _('Organization is required')}
     )
-    organization_contact = serializers.PrimaryKeyRelatedField(
-        allow_null=True, queryset=OrganizationContact.objects.all(),
+    organization_contact = OrganizationContactSubmitSerializer(
         error_messages={'null': _('Organization contact is required')}
     )
 

--- a/bluebottle/initiatives/tests/test_model.py
+++ b/bluebottle/initiatives/tests/test_model.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 
 from bluebottle.test.factory_models.accounts import BlueBottleUserFactory
 from bluebottle.test.factory_models.organizations import OrganizationFactory
-from bluebottle.initiatives.tests.factories import InitiativeFactory
+from bluebottle.initiatives.tests.factories import InitiativeFactory, InitiativePlatformSettingsFactory
 
 
 class InitiativeTestCase(TestCase):
@@ -58,3 +58,15 @@ class InitiativeTestCase(TestCase):
         initiative = InitiativeFactory(has_organization=False, organization=None, owner=member)
 
         self.assertIsNone(initiative.organization)
+
+    def test_organization_required(self):
+        InitiativePlatformSettingsFactory.create(require_organization=True)
+
+        initiative = InitiativeFactory()
+        self.assertTrue(initiative.has_organization)
+
+    def test_organization_not_required(self):
+        InitiativePlatformSettingsFactory.create(require_organization=False)
+
+        initiative = InitiativeFactory()
+        self.assertFalse(initiative.has_organization)

--- a/bluebottle/initiatives/tests/test_transitions.py
+++ b/bluebottle/initiatives/tests/test_transitions.py
@@ -3,13 +3,14 @@ from bluebottle.initiatives.transitions import InitiativeTransitions
 from bluebottle.test.utils import BluebottleTestCase
 
 from bluebottle.initiatives.tests.factories import InitiativeFactory
+from bluebottle.test.factory_models.organizations import OrganizationFactory, OrganizationContactFactory
 
 
 class InitiativeTransitionTestCase(BluebottleTestCase):
     def setUp(self):
         super(InitiativeTransitionTestCase, self).setUp()
 
-        self.initiative = InitiativeFactory.create()
+        self.initiative = InitiativeFactory.create(has_organization=False, organization=None)
 
     def test_default_status(self):
         self.assertEqual(
@@ -28,6 +29,42 @@ class InitiativeTransitionTestCase(BluebottleTestCase):
         self.assertRaises(
             TransitionNotPossible,
             self.initiative.transitions.submit
+        )
+
+    def test_submit_has_organization_missing(self):
+        self.initiative.has_organization = True
+
+        self.assertRaises(
+            TransitionNotPossible,
+            self.initiative.transitions.submit
+        )
+
+    def test_submit_has_organization_missing_contact(self):
+        self.initiative.has_organization = True
+
+        self.assertRaises(
+            TransitionNotPossible,
+            self.initiative.transitions.submit
+        )
+
+    def test_submit_has_organization_no_contact_name(self):
+        self.initiative.has_organization = True
+        self.initiative.organization = OrganizationFactory.create()
+        self.initiative.organization_contact = OrganizationContactFactory.create(name=None)
+
+        self.assertRaises(
+            TransitionNotPossible,
+            self.initiative.transitions.submit
+        )
+
+    def test_submit_has_organization(self):
+        self.initiative.has_organization = True
+        self.initiative.organization = OrganizationFactory.create()
+        self.initiative.organization_contact = OrganizationContactFactory.create()
+
+        self.initiative.transitions.submit()
+        self.assertEqual(
+            self.initiative.status, InitiativeTransitions.values.submitted
         )
 
     def test_needs_work(self):

--- a/bluebottle/initiatives/transitions.py
+++ b/bluebottle/initiatives/transitions.py
@@ -20,9 +20,13 @@ class InitiativeTransitions(ModelTransitions):
     def is_complete(self):
         from bluebottle.initiatives.serializers import InitiativeSubmitSerializer
 
-        serializer = InitiativeSubmitSerializer(
-            data=model_to_dict(self.instance)
-        )
+        data = model_to_dict(self.instance)
+        if self.instance.organization:
+            data['organization'] = model_to_dict(self.instance.organization)
+        if self.instance.organization_contact:
+            data['organization_contact'] = model_to_dict(self.instance.organization_contact)
+
+        serializer = InitiativeSubmitSerializer(data=data)
         if not serializer.is_valid():
             return [unicode(error) for errors in serializer.errors.values() for error in errors]
 


### PR DESCRIPTION
Always set `has_organization` when setting is set to true.
Validate submit transition correctly when `has_organization` is true.

BB-14454 #resolve