### PR TITLE
adds initiative.location and initiative.place to activities serializer

### DIFF
--- a/bluebottle/activities/serializers.py
+++ b/bluebottle/activities/serializers.py
@@ -20,7 +20,9 @@ class ActivitySerializer(PolymorphicModelSerializer):
         'owner': 'bluebottle.initiatives.serializers.MemberSerializer',
         'initiative': 'bluebottle.initiatives.serializers.InitiativeSerializer',
         'initiative.image': 'bluebottle.initiatives.serializers.InitiativeImageSerializer',
-        'location': 'bluebottle.geo.serializers.GeolocationSerializer',
+        'location': 'bluebottle.geo.serializers.GeolocationSerializer',    
+        'initiative.location': 'bluebottle.geo.serializers.LocationSerializer',
+        'initiative.place': 'bluebottle.geo.serializers.GeolocationSerializer',    
     }
 
     class Meta:
@@ -31,7 +33,9 @@ class ActivitySerializer(PolymorphicModelSerializer):
             'owner',
             'initiative',
             'location',
-            'initiative.image'
+            'initiative.image',
+            'initiative.place',
+            'initiative.location',
         ]
 
 

--- a/bluebottle/activities/serializers.py
+++ b/bluebottle/activities/serializers.py
@@ -20,9 +20,9 @@ class ActivitySerializer(PolymorphicModelSerializer):
         'owner': 'bluebottle.initiatives.serializers.MemberSerializer',
         'initiative': 'bluebottle.initiatives.serializers.InitiativeSerializer',
         'initiative.image': 'bluebottle.initiatives.serializers.InitiativeImageSerializer',
-        'location': 'bluebottle.geo.serializers.GeolocationSerializer',    
+        'location': 'bluebottle.geo.serializers.GeolocationSerializer',
         'initiative.location': 'bluebottle.geo.serializers.LocationSerializer',
-        'initiative.place': 'bluebottle.geo.serializers.GeolocationSerializer',    
+        'initiative.place': 'bluebottle.geo.serializers.GeolocationSerializer',
     }
 
     class Meta:

--- a/bluebottle/funding/tests/test_api.py
+++ b/bluebottle/funding/tests/test_api.py
@@ -10,6 +10,7 @@ from bluebottle.funding.tests.factories import FundingFactory, FundraiserFactory
 from bluebottle.funding.transitions import DonationTransitions
 from bluebottle.initiatives.tests.factories import InitiativeFactory
 from bluebottle.test.factory_models.accounts import BlueBottleUserFactory
+from bluebottle.test.factory_models.geo import GeolocationFactory
 from bluebottle.test.utils import BluebottleTestCase, JSONAPITestClient, get_included
 
 
@@ -193,7 +194,8 @@ class FundingDetailTestCase(BluebottleTestCase):
         super(FundingDetailTestCase, self).setUp()
         self.client = JSONAPITestClient()
         self.user = BlueBottleUserFactory()
-        self.initiative = InitiativeFactory.create()
+        self.geolocation = GeolocationFactory.create(locality='Barranquilla')
+        self.initiative = InitiativeFactory.create(place=self.geolocation)
 
         self.initiative.transitions.submit()
         self.initiative.transitions.approve()
@@ -249,6 +251,10 @@ class FundingDetailTestCase(BluebottleTestCase):
             len(data['data']['relationships']['contributions']['data']),
             5
         )
+
+        # Test that geolocation is included too
+        geolocation = get_included(response, 'geolocations')
+        self.assertEqual(geolocation['attributes']['locality'], 'Barranquilla')
 
 
 class FundraiserListTestCase(BluebottleTestCase):

--- a/bluebottle/test/factory_models/geo.py
+++ b/bluebottle/test/factory_models/geo.py
@@ -67,5 +67,6 @@ class GeolocationFactory(factory.DjangoModelFactory):
     class Meta(object):
         model = Geolocation
 
+    locality = factory.Faker('text')
     position = Point(13.4, 52.5)
     country = factory.SubFactory(CountryFactory)


### PR DESCRIPTION
In the activities list call, the place or location of the initiative wasn't included. This is used in the funding cards.