### PR TITLE
Make sure we strip spaces for ip address taken from the

### DIFF
--- a/bluebottle/utils/tests/test_unit.py
+++ b/bluebottle/utils/tests/test_unit.py
@@ -683,7 +683,13 @@ class GetClientIPTestCase(TestCase):
         self.assertEqual(ip, '127.0.0.1')
 
     def test_get_client_ip_no_spoofing(self):
-        request = RequestFactory().get('/', HTTP_REMOTE_ADDR='8.8.8.8,127.0.0.1')
+        request = RequestFactory().get('/', HTTP_X_FORWARDED_FOR='8.8.8.8,127.0.0.1')
+
+        ip = get_client_ip(request)
+        self.assertEqual(ip, '127.0.0.1')
+
+    def test_get_client_ip_extra_spaces(self):
+        request = RequestFactory().get('/', HTTP_X_FORWARDED_FOR='8.8.8.8, 127.0.0.1 ')
 
         ip = get_client_ip(request)
         self.assertEqual(ip, '127.0.0.1')

--- a/bluebottle/utils/utils.py
+++ b/bluebottle/utils/utils.py
@@ -131,7 +131,7 @@ def get_client_ip(request=None):
         except AttributeError:
             ipa = None
 
-    return ipa.strip()
+    return ipa.strip() if ipa else ipa
 
 
 def set_author_editor_ip(request, obj):

--- a/bluebottle/utils/utils.py
+++ b/bluebottle/utils/utils.py
@@ -130,7 +130,8 @@ def get_client_ip(request=None):
             ipa = request.META.get('REMOTE_ADDR')
         except AttributeError:
             ipa = None
-    return ipa
+
+    return ipa.strip()
 
 
 def set_author_editor_ip(request, obj):


### PR DESCRIPTION
'X-forwarded-for' header.