### PR TITLE
Add organization and organization contact to activity detail serializer.

### DIFF
--- a/bluebottle/activities/serializers.py
+++ b/bluebottle/activities/serializers.py
@@ -64,6 +64,8 @@ class ActivitySerializer(PolymorphicModelSerializer):
         'initiative.image': 'bluebottle.initiatives.serializers.InitiativeImageSerializer',
         'initiative.location': 'bluebottle.geo.serializers.LocationSerializer',
         'initiative.place': 'bluebottle.geo.serializers.GeolocationSerializer',
+        'initiative.organization': 'bluebottle.organizations.serializers.OrganizationSerializer',
+        'initiative.organization_contact': 'bluebottle.organizations.serializers.OrganizationContactSerializer',
     }
 
     class Meta:
@@ -83,6 +85,8 @@ class ActivitySerializer(PolymorphicModelSerializer):
             'initiative.image',
             'initiative.place',
             'initiative.location',
+            'initiative.organization',
+            'initiative.organization_contact',
         ]
 
 


### PR DESCRIPTION
This prevents an error when going from an activity to an inititiatve
with an organization.

BB-15586 #resolve