### PR TITLE
Fix assignment and event transitions

### DIFF
--- a/bluebottle/activities/transitions.py
+++ b/bluebottle/activities/transitions.py
@@ -117,11 +117,24 @@ class ContributionTransitions(ModelTransitions):
         new = ChoiceItem('new', _('new'))
         succeeded = ChoiceItem('succeeded', _('succeeded'))
         failed = ChoiceItem('failed', _('failed'))
+        closed = ChoiceItem('closed', _('closed'))
 
     def is_user(self, user):
         return self.instance.user == user
+
+    def can_review(self, user):
+        # TODO: Make me smart. Do we want to do this with a auth permission?
+        return not user or user.is_staff
 
     def is_activity_manager(self, user):
         return user in [
             self.instance.activity.initiative.activity_manager,
             self.instance.activity.owner]
+
+    @transition(
+        source='*',
+        target=values.closed,
+        permissions=[can_review]
+    )
+    def close(self):
+        self.instance.transitions.close()

--- a/bluebottle/assignments/tests/test_transitions.py
+++ b/bluebottle/assignments/tests/test_transitions.py
@@ -105,12 +105,23 @@ class AssignmentTransitionTestCase(BluebottleTestCase):
 
     def test_close(self):
         self.assignment.review_transitions.approve()
+
+        applicant = ApplicantFactory.create(activity=self.assignment)
+        applicant.transitions.accept()
+        applicant.save()
+
         self.assignment.save()
         self.assignment.transitions.close()
         self.assignment.save()
-        assignment = Assignment.objects.get(pk=self.assignment.pk)
+
+        self.assignment.refresh_from_db()
+        applicant.refresh_from_db()
+
         self.assertEqual(
-            assignment.status, AssignmentTransitions.values.closed
+            self.assignment.status, AssignmentTransitions.values.closed
+        )
+        self.assertEqual(
+            applicant.status, ApplicantTransitions.values.closed
         )
 
     def test_start_no_applicants(self):

--- a/bluebottle/events/tests/test_transitions.py
+++ b/bluebottle/events/tests/test_transitions.py
@@ -126,6 +126,7 @@ class EventReviewTransitionTestCase(BluebottleTestCase):
 
         self.event.refresh_from_db()
         self.assertEqual(self.event.review_status, ReviewTransitions.values.closed)
+        self.assertEqual(self.event.status, EventTransitions.values.closed)
 
 
 class EventTransitionTestCase(BluebottleTestCase):
@@ -230,15 +231,19 @@ class EventTransitionTestCase(BluebottleTestCase):
         )
 
     def test_close(self):
+        participant = ParticipantFactory.create(activity=self.event)
         self.event.transitions.close()
 
         self.assertEqual(
             self.event.status,
             EventTransitions.values.closed
         )
-        self.assertEqual(len(mail.outbox), 2)
-        self.assertEqual(mail.outbox[1].subject, "Your event has been closed")
-        self.assertTrue("Hi Nono,", mail.outbox[1].body)
+        self.assertEqual(len(mail.outbox), 3)
+        self.assertEqual(mail.outbox[2].subject, "Your event has been closed")
+        self.assertTrue("Hi Nono,", mail.outbox[2].body)
+
+        participant.refresh_from_db()
+        self.assertEqual(participant.status, ParticipantTransitions.values.closed)
 
     def test_extend(self):
         self.event.transitions.close()

--- a/bluebottle/events/transitions.py
+++ b/bluebottle/events/transitions.py
@@ -88,7 +88,9 @@ class EventTransitions(ActivityTransitions):
         permissions=[ActivityTransitions.can_approve]
     )
     def close(self):
-        pass
+        for participant in self.instance.participants:
+            participant.transitions.close()
+            participant.save()
 
     @transition(
         source=values.closed,


### PR DESCRIPTION
- Make sure that when an event closes, all participants become closed
- When an assignment closes, applicants should be closed too, not failed
- When an applicant succeeds, set the time spent to the duration of the
assignment.

BB-15615 #resolve