### PR TITLE
Use timezone.localize instead of time.replace(timezone).

### DIFF
--- a/bluebottle/events/models.py
+++ b/bluebottle/events/models.py
@@ -97,9 +97,11 @@ class Event(Activity):
     @property
     def start(self):
         if self.start_time and self.start_date:
-            return datetime.datetime.combine(
-                self.start_date,
-                self.start_time.replace(tzinfo=get_current_timezone())
+            return get_current_timezone().localize(
+                datetime.datetime.combine(
+                    self.start_date,
+                    self.start_time
+                )
             )
 
     def save(self, *args, **kwargs):

--- a/bluebottle/events/tests/test_models.py
+++ b/bluebottle/events/tests/test_models.py
@@ -30,7 +30,7 @@ class EventTestCase(BluebottleTestCase):
         self.assertEqual(activity.get_absolute_url(), expected)
 
     def test_full(self):
-        start = now() + timedelta(hours=1)
+        start = now() + timedelta(hours=2)
         event = EventFactory.create(
             title='The greatest event',
             start_date=start.date(),
@@ -45,7 +45,7 @@ class EventTestCase(BluebottleTestCase):
         self.assertEqual(event.status, 'full')
 
     def test_reopen_changed_capacity(self):
-        start = now() + timedelta(hours=1)
+        start = now() + timedelta(hours=2)
         event = EventFactory.create(
             title='The greatest event',
             start_date=start.date(),
@@ -65,7 +65,7 @@ class EventTestCase(BluebottleTestCase):
         self.assertEqual(event.status, 'open')
 
     def test_reopen_delete_participant(self):
-        start = now() + timedelta(hours=1)
+        start = now() + timedelta(hours=2)
         event = EventFactory.create(
             title='The greatest event',
             start_date=start.date(),


### PR DESCRIPTION
The previous will set the timzone to 'Europe/Amsterdam LMT +00:20` ofr
some obscure reason.

Timezone.localize will work correctly.

BB-15726 #resolve