### PR TITLE
Try to submit all fundings when a payout account is submitted.

### DIFF
--- a/bluebottle/funding/messages.py
+++ b/bluebottle/funding/messages.py
@@ -55,3 +55,19 @@ class FundingClosedMessage(TransitionMessage):
 
     def get_recipients(self):
         return [self.obj.owner]
+
+
+class PayoutAccountRejected(TransitionMessage):
+    subject = _(u'Your identity verification needs some work')
+    template = 'messages/payout_account_rejected'
+
+    def get_recipients(self):
+        return [self.obj.owner]
+
+
+class PayoutAccountVerified(TransitionMessage):
+    subject = _(u'Your identity is verified')
+    template = 'messages/payout_account_verified'
+
+    def get_recipients(self):
+        return [self.obj.owner]

--- a/bluebottle/funding/models.py
+++ b/bluebottle/funding/models.py
@@ -572,6 +572,12 @@ class PayoutAccount(ValidatedModelMixin, PolymorphicModel, TransitionsMixin):
     updated = models.DateTimeField(auto_now=True)
     reviewed = models.BooleanField(default=False)
 
+    @property
+    def funding(self):
+        for account in self.external_accounts.all():
+            for funding in account.funding_set.all():
+                return funding
+
 
 class PlainPayoutAccount(PayoutAccount):
     document = DocumentField(blank=True, null=True)

--- a/bluebottle/funding/templates/mails/messages/payout_account_rejected.html
+++ b/bluebottle/funding/templates/mails/messages/payout_account_rejected.html
@@ -1,0 +1,23 @@
+{% extends "base.mail.html" %}
+{% load money %}
+{% load i18n %}
+
+{% block content %}
+    <p class="donation-intro">
+        {% blocktrans with recipient_name=to.first_name %}
+            Hi {{ recipient_name }},<br/>
+           
+
+            We have received some feedback on your identity verification. 
+            Please check out the comments and make the appropriate changes. 
+
+            When you’re ready, you can submit your identity verification again and we’ll make sure it’s reviewed.
+        {% endblocktrans %}
+    </p>
+{% endblock content %} 
+
+{% block action %}
+    <a href="{{ site }}{{ obj.funding.get_absolute_url }}" class="action-email">
+       {% trans 'Go to your activity' context 'email' %}:
+    </a>
+{% endblock %}`

--- a/bluebottle/funding/templates/mails/messages/payout_account_rejected.txt
+++ b/bluebottle/funding/templates/mails/messages/payout_account_rejected.txt
@@ -1,0 +1,17 @@
+{% extends "base.mail.txt" %}
+{% load money %}
+{% load i18n %}
+
+{% block content %}
+{% blocktrans with recipient_name=to.first_name platform_name=tenant context 'email' %}
+Hi {{ recipient_name }},
+
+We have received some feedback on your identity verification. 
+Please check out the comments and make the appropriate changes. 
+When you’re ready, you can submit your identity verification again and we’ll make sure it’s reviewed.
+
+{% endblocktrans %}
+{% endblock content %} 
+{% block action %}
+   {% trans 'Go to your activity' context 'email' %}: {{ obj.funding.get_absolute_url }}
+{% endblock %}`

--- a/bluebottle/funding/templates/mails/messages/payout_account_verified.html
+++ b/bluebottle/funding/templates/mails/messages/payout_account_verified.html
@@ -1,0 +1,22 @@
+{% extends "base.mail.html" %}
+{% load money %}
+{% load i18n %}
+
+{% block content %}
+    <p class="donation-intro">
+        {% blocktrans with recipient_name=to.first_name platform_name=tenant context 'email' %}
+            Hi {{ recipient_name }},<br/>
+           
+            Good news! Your identity is verified and you’re all good to go. 
+
+            If you filled out the entire creation flow, your crowdfunding campaign will be submitted for review. 
+            Didn’t complete your campaign yet? Go to {{ platform_name }} and enter the last details.
+        {% endblocktrans %}
+    </p>
+{% endblock content %} 
+
+{% block action %}
+    <a href="{{ site }}{{ obj.funding.get_absolute_url }}" class="action-email">
+       {% trans 'Go to your activity' context 'email' %}:
+    </a>
+{% endblock %}`

--- a/bluebottle/funding/templates/mails/messages/payout_account_verified.txt
+++ b/bluebottle/funding/templates/mails/messages/payout_account_verified.txt
@@ -1,0 +1,18 @@
+{% extends "base.mail.txt" %}
+{% load money %}
+{% load i18n %}
+
+{% block content %}
+{% blocktrans with recipient_name=to.first_name platform_name=tenant context 'email' %}
+Hi {{ recipient_name }},
+
+Good news! Your identity is verified and you’re all good to go. 
+
+If you filled out the entire creation flow, your crowdfunding campaign will be submitted for review. 
+Didn’t complete your campaign yet? Go to {{ platform_name }} and enter the last details.
+
+{% endblocktrans %}
+{% endblock content %} 
+{% block action %}
+   {% trans 'Go to your activity' context 'email' %}: {{ obj.funding.get_absolute_url }}
+{% endblock %}`

--- a/bluebottle/funding/transitions.py
+++ b/bluebottle/funding/transitions.py
@@ -268,6 +268,16 @@ class PlainPayoutAccountTransitions(PayoutAccountTransitions):
         if self.instance.document:
             self.instance.document.delete()
             self.instance.document = None
+
+        for external_account in self.instance.external_accounts.all():
+            for funding in external_account.funding_set.filter(
+                review_status__in=('draft', 'needs_work')
+            ):
+                try:
+                    funding.review_transitions.submit()
+                except TransitionNotPossible:
+                    pass
+
         self.instance.save()
 
     @transition(

--- a/bluebottle/funding_stripe/models.py
+++ b/bluebottle/funding_stripe/models.py
@@ -367,11 +367,19 @@ class StripePayoutAccount(PayoutAccount):
 
     @property
     def verified(self):
+        return self.status == 'verified'
+
+    @property
+    def complete(self):
         return (
             'individual' in self.account and
             self.account.individual.verification.status == 'verified' and
             not self.account.individual.requirements.eventually_due
         )
+
+    @property
+    def rejected(self):
+        return self.account.individual.verification.status == 'unverified'
 
     @property
     def disabled(self):

--- a/bluebottle/funding_stripe/tests/test_models.py
+++ b/bluebottle/funding_stripe/tests/test_models.py
@@ -106,12 +106,12 @@ class ConnectAccountTestCase(BluebottleTestCase):
 
             retrieve.assert_called_once_with(self.check.account_id)
 
-    def test_verified(self):
+    def test_complete(self):
         self.connect_account.individual.requirements.eventually_due = []
         with mock.patch(
             'stripe.Account.retrieve', return_value=self.connect_account
         ):
-            self.assertTrue(self.check.verified)
+            self.assertTrue(self.check.complete)
 
     def test_not_verified(self):
         with mock.patch(

--- a/bluebottle/funding_stripe/views.py
+++ b/bluebottle/funding_stripe/views.py
@@ -288,13 +288,13 @@ class ConnectWebHookView(View):
                 account = self.get_account(event.data.object.id)
                 if (
                     account.status != PayoutAccountTransitions.values.verified and
-                    account.verified
+                    account.complete
                 ):
                     account.transitions.verify()
 
                 if (
                     account.status != PayoutAccountTransitions.values.rejected and
-                    account.disabled
+                    account.rejected
                 ):
                     account.transitions.reject()
 

--- a/bluebottle/utils/email_backend.py
+++ b/bluebottle/utils/email_backend.py
@@ -155,7 +155,8 @@ def send_mail(template_name=None, subject=None, to=None, attachments=None, **kwa
 
     if not kwargs.get('site'):
         kwargs.update({
-            'site': tenant_url()
+            'site': tenant_url(),
+            'tenant': connection.tenant.client_name
         })
     kwargs.update({
         'settings': MailPlatformSettings.load()


### PR DESCRIPTION
Send message to owner when account is rejected / verified
Fix webhook, reject account when status becomes unverified.
Use status for verification check. This is much faster, since it does
not require a call to stripe.

BB-14634 #resolve