### PR TITLE
Bug/bb 16040 update status when participants or limit changes

### DIFF
--- a/bluebottle/activities/tests/test_api.py
+++ b/bluebottle/activities/tests/test_api.py
@@ -382,7 +382,11 @@ class ActivityListSearchAPITestCase(ESTestCase, BluebottleTestCase):
         self.owner.save()
 
         first = AssignmentFactory.create(review_status='approved', status='full')
+        ApplicantFactory.create_batch(3, activity=first, status='accepted')
+
         second = AssignmentFactory.create(review_status='approved', status='full', expertise=skill)
+        ApplicantFactory.create_batch(3, activity=second, status='accepted')
+
         third = AssignmentFactory.create(review_status='approved', status='open')
         fourth = AssignmentFactory.create(review_status='approved', status='open', expertise=skill)
 
@@ -439,12 +443,16 @@ class ActivityListSearchAPITestCase(ESTestCase, BluebottleTestCase):
         PlaceFactory.create(content_object=self.owner, position='10.0, 20.0')
 
         first = AssignmentFactory.create(review_status='approved', status='full')
+        ApplicantFactory.create_batch(3, activity=first, status='accepted')
+
         second = AssignmentFactory.create(
             review_status='approved',
             status='full',
             is_online=False,
             location=GeolocationFactory.create(position=Point(20.0, 10))
         )
+        ApplicantFactory.create_batch(3, activity=second, status='accepted')
+
         third = AssignmentFactory.create(
             review_status='approved',
             status='open',
@@ -487,8 +495,13 @@ class ActivityListSearchAPITestCase(ESTestCase, BluebottleTestCase):
         initiative4 = InitiativeFactory.create(place=GeolocationFactory.create(country=country2))
 
         first = AssignmentFactory.create(review_status='approved', status='full', initiative=initiative1)
+        ApplicantFactory.create_batch(3, activity=first, status='accepted')
+
         second = AssignmentFactory.create(review_status='approved', status='open', initiative=initiative3)
-        AssignmentFactory.create(review_status='approved', status='full', initiative=initiative2)
+
+        third = AssignmentFactory.create(review_status='approved', status='full', initiative=initiative2)
+        ApplicantFactory.create_batch(3, activity=third, status='accepted')
+
         AssignmentFactory.create(review_status='approved', status='open', initiative=initiative4)
 
         response = self.client.get(
@@ -508,12 +521,16 @@ class ActivityListSearchAPITestCase(ESTestCase, BluebottleTestCase):
         self.owner.save()
 
         first = AssignmentFactory.create(review_status='approved', status='full')
+        ApplicantFactory.create_batch(3, activity=first, status='accepted')
+
         second = AssignmentFactory.create(
             review_status='approved',
             status='full',
             is_online=False,
             location=GeolocationFactory.create(position=Point(20.0, 10.0))
         )
+        ApplicantFactory.create_batch(3, activity=second, status='accepted')
+
         third = AssignmentFactory.create(review_status='approved', status='open')
         fourth = AssignmentFactory.create(
             review_status='approved',

--- a/bluebottle/assignments/models.py
+++ b/bluebottle/assignments/models.py
@@ -192,5 +192,8 @@ class Applicant(Contribution):
             self.transitions.initiate()
         self.activity.check_capacity()
 
+    def delete(self, *args, **kwargs):
+        super(Applicant, self).delete(*args, **kwargs)
+        self.activity.check_capacity()
 
 from bluebottle.assignments.signals import *  # noqa

--- a/bluebottle/assignments/models.py
+++ b/bluebottle/assignments/models.py
@@ -133,7 +133,7 @@ class Assignment(Activity):
 
             self.save()
 
-    def check_capacity(self):
+    def check_capacity(self, save=True):
         if self.capacity \
                 and len(self.accepted_applicants) >= self.capacity \
                 and self.status == AssignmentTransitions.values.open:
@@ -143,7 +143,12 @@ class Assignment(Activity):
                 and len(self.accepted_applicants) < self.capacity \
                 and self.status == AssignmentTransitions.values.full:
             self.transitions.reopen()
-            self.save()
+            if save:
+                self.save()
+
+    def save(self, *args, **kwargs):
+        self.check_capacity(save=False)
+        return super(Assignment, self).save(*args, **kwargs)
 
 
 class Applicant(Contribution):

--- a/bluebottle/assignments/tests/test_models.py
+++ b/bluebottle/assignments/tests/test_models.py
@@ -70,3 +70,34 @@ class AssignmentTestCase(BluebottleTestCase):
         assignment.save()
 
         self.assertEqual(len(mail.outbox), 0)
+
+    def test_check_status_capacity_changed(self):
+        assignment = AssignmentFactory(
+            title='Test Title',
+            status='open',
+            end_date=date.today() + timedelta(days=4),
+            capacity=3,
+        )
+        ApplicantFactory.create_batch(3, activity=assignment, status='accepted')
+
+        self.assertEqual(assignment.status, 'full')
+
+        assignment.capacity = 10
+        assignment.save()
+
+        self.assertEqual(assignment.status, 'open')
+
+    def test_check_status_applicant_removed(self):
+        assignment = AssignmentFactory(
+            title='Test Title',
+            status='open',
+            end_date=date.today() + timedelta(days=4),
+            capacity=3,
+        )
+        applicants = ApplicantFactory.create_batch(3, activity=assignment, status='accepted')
+
+        self.assertEqual(assignment.status, 'full')
+
+        applicants[0].delete()
+
+        self.assertEqual(assignment.status, 'open')


### PR DESCRIPTION
When a task is full and the activity manager increases the number of people needed, the task detail page still shows that the task is full

https://onepercentclub.atlassian.net/browse/BB-16040

- BB-16068 Backend: status doesn't change when number of people needed increases
- BB-16069 Backend: Capacity not checked when participan is removed

