### PR TITLE
Fix unicode filenames in cache bust parameter.

### DIFF
--- a/bluebottle/files/serializers.py
+++ b/bluebottle/files/serializers.py
@@ -123,7 +123,7 @@ class ImageSerializer(DocumentSerializer):
             try:
                 relationship = getattr(obj, self.relationship)
                 parent_id = getattr(obj, self.relationship).get().pk
-                hash = md5.new(obj.file.name).hexdigest()
+                hash = md5.new(obj.file.name.encode('utf-8')).hexdigest()
                 return dict(
                     (
                         key,


### PR DESCRIPTION
Calculating the md5 of a unicode filename will fail, breaking the
serializer.

BB-16045 #resolve