### PR TITLE
Make it possible to transition `partial` / `succeeded` fundings to "o…

### DIFF
--- a/bluebottle/activities/admin.py
+++ b/bluebottle/activities/admin.py
@@ -79,12 +79,11 @@ class ActivityChildAdmin(PolymorphicChildModelAdmin, FSMAdmin):
     )
 
     def get_status_fields(self, request, obj=None):
-        if obj and obj.status == 'in_review':
+        if obj and obj.review_status != 'approved':
             return [
                 'title',
                 'complete',
                 'valid',
-                'status',
                 'review_status',
                 'review_transitions',
                 'transition_date'

--- a/bluebottle/activities/admin.py
+++ b/bluebottle/activities/admin.py
@@ -79,7 +79,7 @@ class ActivityChildAdmin(PolymorphicChildModelAdmin, FSMAdmin):
     )
 
     def get_status_fields(self, request, obj=None):
-        if obj and obj.review_status != 'approved':
+        if obj and obj.review_status != ActivityReviewTransitions.values.approved:
             return [
                 'title',
                 'complete',

--- a/bluebottle/funding/admin.py
+++ b/bluebottle/funding/admin.py
@@ -240,7 +240,7 @@ class FundingAdmin(ActivityChildAdmin):
     payout_links.short_description = _('Payouts')
 
     def combined_status(self, obj):
-        if obj.review_status != 'approved':
+        if obj.review_status != ActivityReviewTransitions.values.approved:
             return obj.review_status
         return obj.status
     combined_status.short_description = _('status')

--- a/bluebottle/funding/admin.py
+++ b/bluebottle/funding/admin.py
@@ -240,7 +240,7 @@ class FundingAdmin(ActivityChildAdmin):
     payout_links.short_description = _('Payouts')
 
     def combined_status(self, obj):
-        if obj.status == 'in_review':
+        if obj.review_status != 'approved':
             return obj.review_status
         return obj.status
     combined_status.short_description = _('status')

--- a/bluebottle/funding/tests/test_transitions.py
+++ b/bluebottle/funding/tests/test_transitions.py
@@ -5,6 +5,7 @@ from django.core import mail
 from django.utils.timezone import now
 from moneyed import Money
 
+from bluebottle.fsm import TransitionNotPossible
 from bluebottle.funding.tasks import check_funding_end
 from bluebottle.funding.tests.factories import FundingFactory, DonationFactory, \
     BudgetLineFactory, BankAccountFactory
@@ -115,3 +116,36 @@ class FundingTestCase(BluebottleAdminTestCase):
         self.assertEqual(len(mail.outbox), 5)
         self.assertEqual(mail.outbox[4].subject, u'You successfully completed your crowdfunding campaign! 🎉')
         self.assertTrue('Hi Jean Baptiste,' in mail.outbox[4].body)
+
+    def test_reopen(self):
+        donation = DonationFactory.create(activity=self.funding, amount=Money(1000, 'EUR'))
+        PledgePaymentFactory.create(donation=donation)
+
+        self.funding.deadline = now() - timedelta(days=1)
+        self.funding.save()
+        check_funding_end()
+
+        self.funding.refresh_from_db()
+        self.assertEqual(self.funding.status, 'succeeded')
+
+        self.funding.deadline = now() + timedelta(days=1)
+        self.funding.save()
+
+        self.funding.transitions.reopen()
+        self.assertEqual(self.funding.status, 'open')
+
+    def test_reopen_past_deadline(self):
+        donation = DonationFactory.create(activity=self.funding, amount=Money(1000, 'EUR'))
+        PledgePaymentFactory.create(donation=donation)
+
+        self.funding.deadline = now() - timedelta(days=1)
+        self.funding.save()
+        check_funding_end()
+
+        self.funding.refresh_from_db()
+        self.assertEqual(self.funding.status, 'succeeded')
+
+        self.assertRaises(
+            TransitionNotPossible,
+            self.funding.transitions.reopen
+        )

--- a/bluebottle/funding/tests/test_transitions.py
+++ b/bluebottle/funding/tests/test_transitions.py
@@ -117,7 +117,7 @@ class FundingTestCase(BluebottleAdminTestCase):
         self.assertEqual(mail.outbox[4].subject, u'You successfully completed your crowdfunding campaign! 🎉')
         self.assertTrue('Hi Jean Baptiste,' in mail.outbox[4].body)
 
-    def test_reopen(self):
+    def test_extend(self):
         donation = DonationFactory.create(activity=self.funding, amount=Money(1000, 'EUR'))
         PledgePaymentFactory.create(donation=donation)
 
@@ -131,10 +131,10 @@ class FundingTestCase(BluebottleAdminTestCase):
         self.funding.deadline = now() + timedelta(days=1)
         self.funding.save()
 
-        self.funding.transitions.reopen()
+        self.funding.transitions.extend()
         self.assertEqual(self.funding.status, 'open')
 
-    def test_reopen_past_deadline(self):
+    def test_extend_past_deadline(self):
         donation = DonationFactory.create(activity=self.funding, amount=Money(1000, 'EUR'))
         PledgePaymentFactory.create(donation=donation)
 
@@ -147,5 +147,5 @@ class FundingTestCase(BluebottleAdminTestCase):
 
         self.assertRaises(
             TransitionNotPossible,
-            self.funding.transitions.reopen
+            self.funding.transitions.extend
         )

--- a/bluebottle/funding/transitions.py
+++ b/bluebottle/funding/transitions.py
@@ -65,7 +65,7 @@ class FundingTransitions(ActivityTransitions):
         conditions=[deadline_in_future],
         permissions=[ActivityTransitions.can_approve]
     )
-    def reopen(self):
+    def extend(self):
         pass
 
     @transition(

--- a/bluebottle/funding/transitions.py
+++ b/bluebottle/funding/transitions.py
@@ -25,6 +25,10 @@ class FundingTransitions(ActivityTransitions):
         if not self.instance.amount_raised >= self.instance.target:
             return _("Amount raised should at least equal to target amount.")
 
+    def deadline_in_future(self):
+        if not self.instance.deadline >= timezone.now():
+            return _("The deadline of the activity should be in the future.")
+
     @transition(
         source=values.in_review,
         target=values.open,
@@ -54,6 +58,15 @@ class FundingTransitions(ActivityTransitions):
     def succeed(self):
         from bluebottle.funding.models import Payout
         Payout.generate(self.instance)
+
+    @transition(
+        source=[values.succeeded, values.partially_funded],
+        target=values.open,
+        conditions=[deadline_in_future],
+        permissions=[ActivityTransitions.can_approve]
+    )
+    def reopen(self):
+        pass
 
     @transition(
         source=[values.succeeded, values.partially_funded],


### PR DESCRIPTION
…pen".

- Also show review_status when that is not approved. This shows the
correct transition when activities are closed

BB-16155 #resolve