### PR TITLE
Force unicode in subject field

### DIFF
--- a/bluebottle/notifications/messages.py
+++ b/bluebottle/notifications/messages.py
@@ -74,7 +74,7 @@ class TransitionMessage(object):
                         pass
 
                 context = self.get_context(recipient)
-                subject = self.subject.format(**context)
+                subject = unicode(self.subject.format(**context))
 
                 body_html = None
                 body_txt = None


### PR DESCRIPTION
test_send_translated_messages
    self.assertEqual(mail.outbox[0].subject, "Test message")
AssertionError: u'Test bericht' != 'Test message'