### PR TITLE
Make sure that long paths do not cause errors when recording user

### DIFF
--- a/bluebottle/members/serializers.py
+++ b/bluebottle/members/serializers.py
@@ -19,7 +19,7 @@ from bluebottle.organizations.serializers import OrganizationSerializer
 from bluebottle.projects.models import Project
 from bluebottle.donations.models import Donation
 from bluebottle.tasks.models import Skill, Task, TaskMember
-from bluebottle.utils.serializers import PermissionField
+from bluebottle.utils.serializers import PermissionField, TruncatedCharField
 
 BB_USER_MODEL = get_user_model()
 
@@ -159,7 +159,7 @@ class UserActivitySerializer(serializers.ModelSerializer):
     """
     Serializer for user activity (log paths)
     """
-    path = serializers.CharField(required=False)
+    path = TruncatedCharField(length=200, required=False)
 
     class Meta:
         model = UserActivity

--- a/bluebottle/members/tests/test_api.py
+++ b/bluebottle/members/tests/test_api.py
@@ -581,3 +581,15 @@ class UserActivityTest(BluebottleTestCase):
         data = {'path': '/'}
         response = self.client.post(self.user_activity_url, data)
         self.assertEqual(response.status_code, 401)
+
+    def test_log_activity_long_path(self):
+        data = {'path': '/' + ('a' * 300)}
+        response = self.client.post(self.user_activity_url, data, token=self.user_token)
+        self.assertEqual(response.status_code, 201)
+
+        activity = UserActivity.objects.get()
+
+        self.assertEqual(
+            len(activity.path), 200
+        )
+        self.assertTrue(activity.path.startswith('/aaaaaaa'))

--- a/bluebottle/utils/serializers.py
+++ b/bluebottle/utils/serializers.py
@@ -378,3 +378,13 @@ class NoCommitMixin():
             instance.save()
 
         return instance
+
+
+class TruncatedCharField(serializers.CharField):
+    def __init__(self, length, *args, **kwargs):
+        self.length = length
+
+        super(TruncatedCharField, self).__init__(*args, **kwargs)
+
+    def to_internal_value(self, data):
+        return data[:self.length]


### PR DESCRIPTION
activity.