### PR TITLE
Fix wallpost and wallpost photo permissions.

### DIFF
--- a/bluebottle/wallposts/serializers.py
+++ b/bluebottle/wallposts/serializers.py
@@ -141,6 +141,12 @@ class MediaWallpostPhotoSerializer(serializers.ModelSerializer):
                                                        read_only=False,
                                                        queryset=MediaWallpost.objects)
 
+    def validate(self, data):
+        if 'mediawallpost' in data and data['mediawallpost'].author != self.instance.author:
+            raise ValidationError('Wallpost author and photo author should match')
+
+        return data
+
     class Meta:
         model = MediaWallpostPhoto
         fields = ('id', 'photo', 'mediawallpost')
@@ -210,6 +216,7 @@ class SystemWallpostSerializer(WallpostSerializerBase):
 
 class WallpostSerializer(serializers.ModelSerializer):
     type = serializers.ReadOnlyField(source='wallpost_type', required=False)
+    author = UserPreviewSerializer()
 
     def to_representation(self, obj):
         """

--- a/bluebottle/wallposts/urls/api.py
+++ b/bluebottle/wallposts/urls/api.py
@@ -22,7 +22,7 @@ urlpatterns = [
     url(r'^photos/$', MediaWallpostPhotoList.as_view(),
         name='mediawallpost_photo_list'),
     url(r'^photos/(?P<pk>\d+)$', MediaWallpostPhotoDetail.as_view(),
-        name='mediawallpost_photo_list'),
+        name='mediawallpost_photo_detail'),
 
     url(r'^reactions/$', ReactionList.as_view(), name='wallpost_reaction_list'),
     url(r'^reactions/(?P<pk>\d+)$', ReactionDetail.as_view(),

--- a/bluebottle/wallposts/views.py
+++ b/bluebottle/wallposts/views.py
@@ -181,7 +181,7 @@ class MediaWallpostDetail(TextWallpostDetail):
     serializer_class = MediaWallpostSerializer
 
 
-class WallpostDetail(RetrieveUpdateDestroyAPIView):
+class WallpostDetail(RetrieveUpdateDestroyAPIView, SetAuthorMixin):
     queryset = Wallpost.objects.all()
     serializer_class = WallpostSerializer
     permission_classes = (


### PR DESCRIPTION
Make sure it is not possible to change to owner of a wallpost in the
API.
Make sure it is not possible to change the wallpost of a wallpost photo
to a wallpost with a different owner.

If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
