### PR TITLE
Make sure we invalidate the token when updating their email address and

### DIFF
--- a/bluebottle/bb_accounts/views.py
+++ b/bluebottle/bb_accounts/views.py
@@ -275,6 +275,9 @@ class PasswordProtectedMemberUpdateApiView(UpdateAPIView):
         if not self.request.user.check_password(password):
             raise PermissionDenied()
 
+        self.request.user.last_logout = now()
+        self.request.user.save()
+
         return super(PasswordProtectedMemberUpdateApiView, self).perform_update(serializer)
 
 


### PR DESCRIPTION
or their password.

If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
