### PR TITLE
Set stripe payout accounts to incomplete instead of to rejected when

### DIFF
--- a/bluebottle/funding_stripe/models.py
+++ b/bluebottle/funding_stripe/models.py
@@ -407,10 +407,10 @@ class StripePayoutAccount(PayoutAccount):
                     self.transitions.submit()
             else:
                 if self.status != PayoutAccountTransitions.values.rejected:
-                    self.transitions.reject()
+                    self.transitions.set_incomplete()
         else:
-            if self.status != PayoutAccountTransitions.values.rejected:
-                self.transitions.reject()
+            if self.status != PayoutAccountTransitions.values.incomplete:
+                self.transitions.set_incomplete()
 
         externals = self.account['external_accounts']['data']
         for external in externals:

--- a/bluebottle/funding_stripe/models.py
+++ b/bluebottle/funding_stripe/models.py
@@ -406,7 +406,7 @@ class StripePayoutAccount(PayoutAccount):
                     # Submit to transition to pending
                     self.transitions.submit()
             else:
-                if self.status != PayoutAccountTransitions.values.rejected:
+                if self.status != PayoutAccountTransitions.values.incomplete:
                     self.transitions.set_incomplete()
         else:
             if self.status != PayoutAccountTransitions.values.incomplete:


### PR DESCRIPTION
information is missing.

BB-16754 #resolve

If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
