### PR TITLE
Enable activities block plugin for results page

### DIFF
--- a/bluebottle/assignments/models.py
+++ b/bluebottle/assignments/models.py
@@ -192,7 +192,7 @@ class Assignment(Activity):
         elif self.capacity \
                 and len(self.accepted_applicants) < self.capacity \
                 and self.status == AssignmentTransitions.values.full \
-                and self.registration_deadline >= now().date():
+                and (self.registration_deadline or self.date) >= now().date():
             self.transitions.reopen()
             if save:
                 self.save()

--- a/bluebottle/cms/models.py
+++ b/bluebottle/cms/models.py
@@ -27,6 +27,7 @@ class ResultPage(TranslatableModel):
         'ProjectMapBlockPlugin',
         'ProjectsBlockPlugin',
         'QuotesBlockPlugin',
+        'ActivitiesBlockPlugin',
         'ShareResultsBlockPlugin',
         'StatsBlockPlugin',
         'SurveyBlockPlugin',


### PR DESCRIPTION
If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
