### PR TITLE
Disable registration-deadline from event admin

### DIFF
--- a/bluebottle/events/admin.py
+++ b/bluebottle/events/admin.py
@@ -86,7 +86,7 @@ class EventAdmin(ActivityChildAdmin):
         'start',
         'local_start',
         'duration',
-        'registration_deadline',
+        # 'registration_deadline',  # Disabled until feature is ready - BB-16853
         'is_online',
         'location',
         'location_hint',


### PR DESCRIPTION
BB-16853 Can't adjust activity descriptions "Details" in the backoffice + front end
https://onepercentclub.atlassian.net/browse/BB-16853

If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
