### PR TITLE
Make sure that the scim enterprise user extension is not required. DSM

### DIFF
--- a/bluebottle/scim/scim_data/resource_types.py
+++ b/bluebottle/scim/scim_data/resource_types.py
@@ -11,7 +11,7 @@ RESOURCE_TYPES = [{
         {
             "schema":
             "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
-            "required": True
+            "required": False
         }
     ],
     "meta": {


### PR DESCRIPTION
SCIM does not support that. For us this extension is not required
either, so no need to specify it as such.

If applicable

- [x] Added translatable strings to `server-deployment`
- [x] Added translations to `sever-deployment`
