### PR TITLE
Make it possible to create and transfer to non-european connect accounts

### DIFF
--- a/bluebottle/funding_stripe/models.py
+++ b/bluebottle/funding_stripe/models.py
@@ -41,17 +41,25 @@ class PaymentIntent(models.Model):
 
             statement_descriptor = connection.tenant.name[:22]
 
-            account_id = self.donation.activity.bank_account.connect_account.account_id
-            intent = stripe.PaymentIntent.create(
+            connect_account = self.donation.activity.bank_account.connect_account
+            intent_args = dict(
                 amount=int(self.donation.amount.amount * 100),
                 currency=self.donation.amount.currency,
                 transfer_data={
-                    'destination': account_id,
+                    'destination': connect_account.account_id,
                 },
                 statement_descriptor=statement_descriptor,
                 statement_descriptor_suffix=statement_descriptor[:18],
                 metadata=self.metadata
             )
+
+            if connect_account.country not in STRIPE_EUROPEAN_COUNTRY_CODES:
+                intent_args['on_behalf_of'] = connect_account.account_id
+
+            intent = stripe.PaymentIntent.create(
+                **intent_args
+            )
+
             self.intent_id = intent.id
             self.client_secret = intent.client_secret
 
@@ -140,19 +148,23 @@ class StripeSourcePayment(Payment):
         )
 
     def do_charge(self):
-        account_id = self.donation.activity.bank_account.connect_account.account_id
+        connect_account = self.donation.activity.bank_account.connect_account
 
         statement_descriptor = connection.tenant.name[:22]
-        charge = stripe.Charge.create(
+        charge_args = dict(
             amount=int(self.donation.amount.amount * 100),
             currency=self.donation.amount.currency,
-            source=self.source_token,
             transfer_data={
-                'destination': account_id,
+                'destination': connect_account.account_id,
             },
-            statement_descriptor_suffix=statement_descriptor[:18],
+            statement_descriptor=statement_descriptor,
             metadata=self.metadata
         )
+
+        if connect_account.country not in STRIPE_EUROPEAN_COUNTRY_CODES:
+            charge_args['on_behalf_of'] = connect_account.account_id
+
+        charge = stripe.Charge.create(**charge_args)
 
         self.charge_token = charge.id
         self.transitions.charge()
@@ -284,6 +296,15 @@ with open('bluebottle/funding_stripe/data/document_spec.json') as file:
 @memoize(timeout=60 * 60 * 24)
 def get_specs(country):
     return stripe.CountrySpec.retrieve(country)
+
+
+STRIPE_EUROPEAN_COUNTRY_CODES = [
+    "AD", "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE",
+    "FO", "FI", "FR", "DE", "GI", "GR", "GL", "GG", "VA",
+    "HU", "IS", "IE", "IM", "IL", "IT", "JE", "LV", "LI",
+    "LT", "LU", "MT", "MC", "NL", "NO", "PL", "PT", "RO",
+    "PM", "SM", "SK", "SI", "ES", "SE", "TR", "GB"
+]
 
 
 class StripePayoutAccount(PayoutAccount):
@@ -462,7 +483,6 @@ class StripePayoutAccount(PayoutAccount):
         return self._account
 
     def save(self, *args, **kwargs):
-
         if self.account_id and not self.country == self.account.country:
             self.account_id = None
 
@@ -475,12 +495,17 @@ class StripePayoutAccount(PayoutAccount):
             if 'localhost' in url:
                 url = re.sub('localhost', 't.goodup.com', url)
 
+            capabilities = ['transfers']
+
+            if self.country not in STRIPE_EUROPEAN_COUNTRY_CODES:
+                capabilities.append('card_payments')
+
             self._account = stripe.Account.create(
                 country=self.country,
                 type='custom',
                 settings=self.account_settings,
                 business_type='individual',
-                requested_capabilities=["transfers"],
+                requested_capabilities=capabilities,
                 business_profile={
                     'url': url,
                     'mcc': '8398'

--- a/bluebottle/funding_stripe/tests/test_api.py
+++ b/bluebottle/funding_stripe/tests/test_api.py
@@ -65,8 +65,62 @@ class StripePaymentIntentTestCase(BluebottleTestCase):
             'client_secret': 'some client secret',
         })
 
-        with mock.patch('stripe.PaymentIntent.create', return_value=payment_intent):
+        with mock.patch('stripe.PaymentIntent.create', return_value=payment_intent) as create_intent:
             response = self.client.post(self.intent_url, data=json.dumps(self.data), user=self.user)
+            create_intent.assert_called_with(
+                amount=int(self.donation.amount.amount * 100),
+                currency=self.donation.amount.currency,
+                metadata={
+                    'tenant_name': u'test',
+                    'activity_id': self.donation.activity.pk,
+                    'activity_title': self.donation.activity.title,
+                    'tenant_domain': u'testserver'
+                },
+                statement_descriptor=u'Test',
+                statement_descriptor_suffix=u'Test',
+                transfer_data={
+                    'destination': self.bank_account.connect_account.account_id
+                }
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data = json.loads(response.content)
+
+        self.assertEqual(data['data']['attributes']['intent-id'], payment_intent.id)
+        self.assertEqual(data['data']['attributes']['client-secret'], payment_intent.client_secret)
+        self.assertEqual(data['included'][0]['attributes']['status'], 'new')
+
+    def test_create_intent_us(self):
+        self.bank_account.connect_account.account.country = 'US'
+        self.bank_account.connect_account.country = 'US'
+        self.bank_account.connect_account.save()
+
+        self.donation.user = self.user
+        self.donation.save()
+
+        payment_intent = stripe.PaymentIntent('some intent id')
+        payment_intent.update({
+            'client_secret': 'some client secret',
+        })
+
+        with mock.patch('stripe.PaymentIntent.create', return_value=payment_intent) as create_intent:
+            response = self.client.post(self.intent_url, data=json.dumps(self.data), user=self.user)
+            create_intent.assert_called_with(
+                amount=int(self.donation.amount.amount * 100),
+                currency=self.donation.amount.currency,
+                metadata={
+                    'tenant_name': u'test',
+                    'activity_id': self.donation.activity.pk,
+                    'activity_title': self.donation.activity.title,
+                    'tenant_domain': u'testserver'
+                },
+                on_behalf_of=self.bank_account.connect_account.account_id,
+                statement_descriptor=u'Test',
+                statement_descriptor_suffix=u'Test',
+                transfer_data={
+                    'destination': self.bank_account.connect_account.account_id
+                }
+            )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         data = json.loads(response.content)
@@ -377,6 +431,73 @@ class ConnectAccountDetailsTestCase(BluebottleTestCase):
             data['data']['relationships']['owner']['data']['id'],
             unicode(self.user.pk)
         )
+
+    def test_create_us(self):
+        self.check.delete()
+        tenant = connection.tenant
+        tenant.name = 'tst'
+        tenant.save()
+
+        connect_account = stripe.Account('some-connect-id')
+        connect_account.update({
+            'country': self.data['data']['attributes']['country'],
+            'individual': bunch.bunchify({
+                'first_name': 'Jhon',
+                'last_name': 'Example',
+                'email': 'jhon@example.com',
+                'verification': bunch.bunchify({
+                    'status': 'pending',
+                }),
+                'requirements': bunch.bunchify({
+                    'eventually_due': ['external_accounts', 'individual.dob.month'],
+                    'currently_due': [],
+                    'past_due': [],
+                })
+            }),
+            'requirements': bunch.bunchify({
+                'eventually_due': ['external_accounts', 'individual.dob.month'],
+                'disabled': False
+            }),
+            'external_accounts': bunch.bunchify({
+                'total_count': 0,
+                'data': []
+            })
+        })
+
+        self.data['data']['attributes']['country'] = 'US'
+
+        with mock.patch('stripe.CountrySpec.retrieve', return_value=self.country_spec):
+            with mock.patch('stripe.Account.create', return_value=connect_account) as create_account:
+                with mock.patch('stripe.Account.modify', return_value=connect_account) as modify_account:
+                    with mock.patch('stripe.Account.retrieve', return_value=connect_account):
+                        self.client.post(
+                            self.account_list_url, data=json.dumps(self.data), user=self.user
+                        )
+                        create_account.assert_called_with(
+                            business_profile={'url': 'https://testserver', 'mcc': '8398'},
+                            business_type='individual',
+                            country=self.data['data']['attributes']['country'],
+                            metadata={'tenant_name': 'test', 'tenant_domain': 'testserver', 'member_id': self.user.pk},
+                            requested_capabilities=['transfers', 'card_payments'],
+                            settings={
+                                'card_payments': {
+                                    'statement_descriptor_prefix': u'tst--'
+                                },
+                                'payments': {
+                                    'statement_descriptor': u'tst--'
+                                },
+                                'payouts': {
+                                    'statement_descriptor': u'tst--',
+                                    'schedule': {'interval': 'manual'}
+                                }
+                            },
+                            # business_type='individual',
+                            type='custom'
+                        )
+                        modify_account.assert_called_with(
+                            'some-connect-id',
+                            account_token='some-account-token'
+                        )
 
     def test_create_no_user(self):
         self.check.delete()

--- a/bluebottle/funding_stripe/tests/test_webhooks.py
+++ b/bluebottle/funding_stripe/tests/test_webhooks.py
@@ -345,10 +345,72 @@ class SourcePaymentWebhookTestCase(BluebottleTestCase):
                 'source.chargeable', data
             )
         ):
-            with mock.patch('stripe.Charge.create', return_value=charge):
+            with mock.patch('stripe.Charge.create', return_value=charge) as create_charge:
                 response = self.client.post(
                     self.webhook,
                     HTTP_STRIPE_SIGNATURE='some signature'
+                )
+                create_charge.assert_called_with(
+                    amount=int(self.donation.amount.amount * 100),
+                    currency=self.donation.amount.currency,
+                    metadata={
+                        'tenant_name': u'test',
+                        'activity_id': self.funding.pk,
+                        'activity_title': self.funding.title,
+                        'tenant_domain': u'testserver'
+                    },
+                    statement_descriptor=u'Test',
+                    transfer_data={
+                        'destination': self.funding.bank_account.connect_account.account_id
+                    }
+                )
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self._refresh()
+        self.assertEqual(self.donation.status, DonationTransitions.values.new)
+        self.assertEqual(self.payment.status, StripeSourcePaymentTransitions.values.charged)
+
+    def test_source_chargeable_us(self):
+        self.funding.bank_account.connect_account.country = 'US'
+        self.funding.bank_account.connect_account.account.country = 'US'
+        self.funding.bank_account.connect_account.save()
+
+        data = {
+            'object': {
+                'id': self.payment.source_token
+            }
+        }
+        charge = stripe.Charge('some charge token')
+        charge.update({
+            'status': 'succeeded',
+            'refunded': False
+        })
+
+        with mock.patch(
+            'stripe.Webhook.construct_event',
+            return_value=MockEvent(
+                'source.chargeable', data
+            )
+        ):
+            with mock.patch('stripe.Charge.create', return_value=charge) as create_charge:
+                response = self.client.post(
+                    self.webhook,
+                    HTTP_STRIPE_SIGNATURE='some signature'
+                )
+                create_charge.assert_called_with(
+                    amount=int(self.donation.amount.amount * 100),
+                    currency=self.donation.amount.currency,
+                    metadata={
+                        'tenant_name': u'test',
+                        'activity_id': self.funding.pk,
+                        'activity_title': self.funding.title,
+                        'tenant_domain': u'testserver'
+                    },
+                    on_behalf_of=self.funding.bank_account.connect_account.account_id,
+                    statement_descriptor=u'Test',
+                    transfer_data={
+                        'destination': self.funding.bank_account.connect_account.account_id
+                    }
                 )
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
 


### PR DESCRIPTION
If applicable

- [x] Added translatable strings to `server-deployment`
- [x] Added translations to `sever-deployment`
