### PR TITLE
Add original size to image serializer that does not crop, and has a m…

### DIFF
--- a/bluebottle/bluebottle_drf2/serializers.py
+++ b/bluebottle/bluebottle_drf2/serializers.py
@@ -271,6 +271,8 @@ class ImageSerializer(RestrictedImageField):
                 get_thumbnail(value, '600x600', crop=self.crop))
             wide = settings.MEDIA_URL + unicode(
                 get_thumbnail(value, '1024x256', crop=self.crop))
+            original = settings.MEDIA_URL + unicode(
+                get_thumbnail(value, '1920', upscale=False))
 
         except Exception:
             if getattr(settings, 'THUMBNAIL_DEBUG', None):
@@ -285,8 +287,9 @@ class ImageSerializer(RestrictedImageField):
                 'small': request.build_absolute_uri(small),
                 'square': request.build_absolute_uri(square),
                 'wide': request.build_absolute_uri(wide),
+                'original': request.build_absolute_uri(original),
             }
-        return {'full': full, 'large': large, 'small': small, 'square': square}
+        return {'full': full, 'large': large, 'small': small, 'square': square, 'original': original}
 
 
 class PhotoSerializer(RestrictedImageField):

--- a/bluebottle/cms/tests/test_api.py
+++ b/bluebottle/cms/tests/test_api.py
@@ -60,7 +60,7 @@ class ResultPageTestCase(BluebottleTestCase):
             response = self.client.get(self.url)
             self.assertEquals(response.status_code, status.HTTP_200_OK)
             # Image should come in 4 sizes
-            self.assertEqual(len(response.data['image']), 5)
+            self.assertEqual(len(response.data['image']), 6)
             self.assertEqual(response.data['title'], self.page.title)
             self.assertEqual(response.data['description'], self.page.description)
             self.assertEqual(watermark_mock.call_args[0][1]['watermark'], 'test/logo-overlay.png')


### PR DESCRIPTION
…ax-width of 1092

If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
