### PR TITLE
Never auto-submit funding activities. Also not when approving the

### DIFF
--- a/bluebottle/activities/states.py
+++ b/bluebottle/activities/states.py
@@ -123,20 +123,6 @@ class ActivityStateMachine(ModelStateMachine):
         ]
     )
 
-    auto_approve = Transition(
-        [
-            submitted,
-            rejected,
-            needs_work
-        ],
-        open,
-        automatic=True,
-        name=_('Approve'),
-        effects=[
-            RelatedTransitionEffect('organizer', 'succeed')
-        ]
-    )
-
     reject = Transition(
         [
             draft,

--- a/bluebottle/events/states.py
+++ b/bluebottle/events/states.py
@@ -78,7 +78,7 @@ class EventStateMachine(ActivityStateMachine):
         ],
         effects=[
             TransitionEffect(
-                'approve',
+                'auto_approve',
                 conditions=[
                     ActivityStateMachine.initiative_is_approved,
                     should_open
@@ -99,7 +99,7 @@ class EventStateMachine(ActivityStateMachine):
         ]
     )
 
-    approve = Transition(
+    auto_approve = Transition(
         [
             ActivityStateMachine.submitted,
             ActivityStateMachine.rejected

--- a/bluebottle/events/tests/test_api.py
+++ b/bluebottle/events/tests/test_api.py
@@ -581,8 +581,20 @@ class EventTransitionTestCase(BluebottleTestCase):
         data = json.loads(response.content)
         self.assertEqual(data['errors'][0], "Transition is not available")
 
-    def test_approve(self):
+    def test_reject(self):
         self.review_data['data']['attributes']['transition'] = 'reject'
+        response = self.client.post(
+            self.transition_url,
+            json.dumps(self.review_data),
+            user=self.owner
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        data = json.loads(response.content)
+        self.assertEqual(data['errors'][0], "Transition is not available")
+
+    def test_approve(self):
+        self.review_data['data']['attributes']['transition'] = 'approve'
         response = self.client.post(
             self.transition_url,
             json.dumps(self.review_data),

--- a/bluebottle/events/tests/test_api.py
+++ b/bluebottle/events/tests/test_api.py
@@ -582,7 +582,7 @@ class EventTransitionTestCase(BluebottleTestCase):
         self.assertEqual(data['errors'][0], "Transition is not available")
 
     def test_approve(self):
-        self.review_data['data']['attributes']['transition'] = 'approve'
+        self.review_data['data']['attributes']['transition'] = 'reject'
         response = self.client.post(
             self.transition_url,
             json.dumps(self.review_data),

--- a/bluebottle/fsm/effects.py
+++ b/bluebottle/fsm/effects.py
@@ -81,11 +81,11 @@ class BaseTransitionEffect(Effect):
 
     @property
     def transition(self):
-        return self.machine.transitions[self.name]
+        return self.machine.transitions.get(self.name)
 
     @property
     def is_valid(self):
-        return (
+        return self.transition and (
             all(condition(self.machine) for condition in self.conditions) and
             self.transition in self.machine.possible_transitions()
         )

--- a/bluebottle/fsm/serializers.py
+++ b/bluebottle/fsm/serializers.py
@@ -44,10 +44,10 @@ class TransitionSerializer(serializers.Serializer):
         states = getattr(resource, self.field)
         user = self.context['request'].user
 
-        transition = states.transitions[transition_name]
         try:
+            transition = states.transitions[transition_name]
             transition.can_execute(states, user=user, automatic=False)
-        except TransitionNotPossible:
+        except (TransitionNotPossible, KeyError):
             raise ValidationError('Transition is not available')
 
         self.instance = Transition(resource, transition_name, message)

--- a/bluebottle/funding/states.py
+++ b/bluebottle/funding/states.py
@@ -113,25 +113,6 @@ class FundingStateMachine(ActivityStateMachine):
             ),
         ]
     )
-    auto_approve = Transition(
-        [
-            ActivityStateMachine.submitted,
-            ActivityStateMachine.rejected,
-            ActivityStateMachine.needs_work
-        ],
-        ActivityStateMachine.open,
-        automatic=True,
-        name=_('Approve'),
-        effects=[
-            RelatedTransitionEffect('organizer', 'succeed'),
-            SetDateEffect('started'),
-            SetDeadlineEffect,
-            TransitionEffect(
-                'expire',
-                conditions=[should_finish]
-            ),
-        ]
-    )
 
     cancel = Transition(
         [

--- a/bluebottle/initiatives/tests/test_states.py
+++ b/bluebottle/initiatives/tests/test_states.py
@@ -272,7 +272,7 @@ class InitiativeReviewStateMachineTests(BluebottleTestCase):
         )
         funding.refresh_from_db()
         self.assertEqual(
-            funding.status, FundingStateMachine.open.value
+            funding.status, FundingStateMachine.submitted.value
         )
 
     def test_reject(self):


### PR DESCRIPTION
initiative.

Fix effects when auto-submitting events.

If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
