### PR TITLE
Set organizer to when restoring an assigment

### DIFF
--- a/bluebottle/assignments/states.py
+++ b/bluebottle/assignments/states.py
@@ -189,7 +189,7 @@ class AssignmentStateMachine(ActivityStateMachine):
         automatic=False,
         description=_("Restore a cancelled, rejected or deleted task."),
         effects=[
-            RelatedTransitionEffect('organizer', 'fail'),
+            RelatedTransitionEffect('organizer', 'reset'),
             RelatedTransitionEffect('accepted_applicants', 'fail')
 
         ]


### PR DESCRIPTION
If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
