### PR TITLE
Remove django-money-rates

### DIFF
--- a/bluebottle/bb_fundraisers/models.py
+++ b/bluebottle/bb_fundraisers/models.py
@@ -3,9 +3,9 @@ from django.db import models
 from django.db.models.aggregates import Sum
 from django.utils.translation import ugettext_lazy as _
 from django_extensions.db.fields import ModificationDateTimeField, CreationDateTimeField
+from djmoney.contrib.exchange.models import convert_money
 from moneyed import Money
 
-from bluebottle.utils.exchange_rates import convert
 from bluebottle.utils.fields import ImageField, MoneyField
 from bluebottle.utils.utils import StatusDefinition
 from bluebottle.wallposts.models import Wallpost
@@ -52,7 +52,7 @@ class BaseFundraiser(models.Model):
             donations.values('amount_currency').annotate(Sum('amount')).order_by()
         ]
 
-        totals = [convert(amount, self.amount.currency) for amount in totals]
+        totals = [convert_money(amount, self.amount.currency) for amount in totals]
 
         return sum(totals) or Money(0, self.amount.currency)
 

--- a/bluebottle/clients/tests/test_api.py
+++ b/bluebottle/clients/tests/test_api.py
@@ -136,6 +136,7 @@ class TestDefaultAPI(ESTestCase, BluebottleTestCase):
     Test the default API, open and closed, authenticated or not
     with default permissions
     """
+
     def setUp(self):
         super(TestDefaultAPI, self).setUp()
 

--- a/bluebottle/clients/utils.py
+++ b/bluebottle/clients/utils.py
@@ -107,7 +107,7 @@ def get_currencies():
         if currency['code'] in min_amounts:
             currency['minAmount'] = min_amounts[currency['code']]
         try:
-            currency['rate'] = get_rate(currency['code'], properties.DEFAULT_CURRENCY)
+            currency['rate'] = get_rate(properties.DEFAULT_CURRENCY, currency['code'])
         except (MissingRate, ProgrammingError):
             currency['rate'] = 1
 

--- a/bluebottle/clients/utils.py
+++ b/bluebottle/clients/utils.py
@@ -12,8 +12,8 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured
 from django.db import connection, ProgrammingError
 from django.utils.translation import get_language
-from djmoney_rates.exceptions import CurrencyConversionException
-from djmoney_rates.utils import get_rate
+from djmoney.contrib.exchange.exceptions import MissingRate
+from djmoney.contrib.exchange.models import get_rate
 from tenant_extras.utils import get_tenant_properties
 
 from bluebottle.clients import properties
@@ -107,8 +107,8 @@ def get_currencies():
         if currency['code'] in min_amounts:
             currency['minAmount'] = min_amounts[currency['code']]
         try:
-            currency['rate'] = get_rate(currency['code'])
-        except (CurrencyConversionException, ProgrammingError):
+            currency['rate'] = get_rate(currency['code'], properties.DEFAULT_CURRENCY)
+        except (MissingRate, ProgrammingError):
             currency['rate'] = 1
 
     return currencies

--- a/bluebottle/funding/tasks.py
+++ b/bluebottle/funding/tasks.py
@@ -2,6 +2,7 @@ import logging
 
 from celery.schedules import crontab
 from celery.task import periodic_task
+from djmoney.contrib.exchange.backends import OpenExchangeRatesBackend
 
 from bluebottle.clients.models import Client
 from bluebottle.clients.utils import LocalTenant
@@ -20,3 +21,12 @@ def funding_tasks():
         with LocalTenant(tenant, clear_tenant=True):
             for task in Funding.get_periodic_tasks():
                 task.execute()
+
+
+@periodic_task(
+    run_every=(crontab(minute='*')),
+    name="update_rates",
+    ignore_result=True
+)
+def update_rates():
+    OpenExchangeRatesBackend().update_rates()

--- a/bluebottle/funding/tests/factories.py
+++ b/bluebottle/funding/tests/factories.py
@@ -43,10 +43,11 @@ class PaymentFactory(factory.DjangoModelFactory):
 
 
 class RewardFactory(factory.DjangoModelFactory):
+    activity = factory.SubFactory(FundingFactory)
+    amount = Money(35, 'EUR')
+
     class Meta(object):
         model = Reward
-
-    activity = factory.SubFactory(FundingFactory)
 
 
 class FundraiserFactory(factory.DjangoModelFactory):
@@ -59,10 +60,11 @@ class FundraiserFactory(factory.DjangoModelFactory):
 
 
 class BudgetLineFactory(factory.DjangoModelFactory):
+    amount = Money(35, 'EUR')
+    activity = factory.SubFactory(FundingFactory)
+
     class Meta(object):
         model = BudgetLine
-
-    activity = factory.SubFactory(FundingFactory)
 
 
 class PlainPayoutAccountFactory(factory.DjangoModelFactory):

--- a/bluebottle/initiatives/models.py
+++ b/bluebottle/initiatives/models.py
@@ -5,6 +5,7 @@ from django.db.models.deletion import SET_NULL
 from django.template.defaultfilters import slugify
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
+from djmoney.contrib.exchange.models import convert_money
 from moneyed import Money
 from multiselectfield import MultiSelectField
 
@@ -16,7 +17,6 @@ from bluebottle.geo.models import Geolocation, Location
 from bluebottle.initiatives.messages import AssignedReviewerMessage
 from bluebottle.initiatives.validators import UniqueTitleValidator
 from bluebottle.organizations.models import Organization, OrganizationContact
-from bluebottle.utils.exchange_rates import convert
 from bluebottle.utils.models import BasePlatformSettings, ValidatedModelMixin, AnonymizationMixin
 from bluebottle.utils.utils import get_current_host, get_current_language, clean_html
 
@@ -152,7 +152,7 @@ class Initiative(TriggerMixin, AnonymizationMixin, ValidatedModelMixin, models.M
             'contributions': sum(stat['count'] for stat in stats),
             'hours': sum(stat['hours'] or 0 for stat in stats if 'hours' in stat),
             'amount': sum(
-                convert(Money(stat['amount']['amount'], stat['amount']['currency']), currency).amount
+                convert_money(Money(stat['amount']['amount'], stat['amount']['currency']), currency).amount
                 for stat in stats if 'amount' in stat
             ),
         }

--- a/bluebottle/projects/models.py
+++ b/bluebottle/projects/models.py
@@ -17,6 +17,7 @@ from django.utils.translation import ugettext_lazy as _
 from django_extensions.db.fields import ModificationDateTimeField, CreationDateTimeField
 
 from django_summernote.models import AbstractAttachment
+from djmoney.contrib.exchange.models import convert_money
 
 from moneyed.classes import Money
 from polymorphic.models import PolymorphicModel
@@ -31,7 +32,6 @@ from bluebottle.clients import properties
 from bluebottle.clients.utils import LocalTenant
 from bluebottle.funding.models import PaymentProvider
 from bluebottle.tasks.models import Task, TaskMember
-from bluebottle.utils.exchange_rates import convert
 from bluebottle.utils.fields import LegacyMoneyField as MoneyField
 from bluebottle.utils.managers import UpdateSignalsQuerySet
 from bluebottle.utils.models import BasePlatformSettings
@@ -350,7 +350,7 @@ class Project(BaseProject, PreviousStatusMixin):
         totals = donations.values('amount_currency').annotate(total=Sum('amount'))
         amounts = [Money(total['total'], total['amount_currency']) for total in totals]
 
-        amounts = [convert(amount, self.amount_asked.currency) for amount in amounts]
+        amounts = [convert_money(amount, self.amount_asked.currency) for amount in amounts]
 
         return sum(amounts) or Money(0, self.amount_asked.currency)
 

--- a/bluebottle/settings/admin_dashboard.py
+++ b/bluebottle/settings/admin_dashboard.py
@@ -328,8 +328,8 @@ JET_SIDE_MENU_ITEMS = [
                 'permissions': ['funding.change_paymentprovider']
             },
             {
-                'name': 'djmoney_rates.ratesource',
-                'permissions': ['djmoney_rates.change_ratesource']
+                'name': 'exchange.exchangebackend',
+                'permissions': ['exchange.change_exchangebackend']
             },
             {
                 'label': _('Manage Reporting'),

--- a/bluebottle/settings/base.py
+++ b/bluebottle/settings/base.py
@@ -292,6 +292,8 @@ SHARED_APPS = (
     'django_singleton_admin',
     'django_filters',
     'multiselectfield',
+
+    'djmoney.contrib.exchange',
 )
 
 TENANT_APPS = (
@@ -427,7 +429,6 @@ TENANT_APPS = (
     'bluebottle.cms',
 
     'djmoney',
-    'djmoney.contrib.exchange',
     'django_singleton_admin',
     'nested_inline',
     'permissions_widget',
@@ -930,8 +931,7 @@ STATIC_MAPS_API_KEY = ''
 STATIC_MAPS_API_SECRET = ''
 
 # django money settings
-OPEN_EXCHANGE_RATES_URL = 'http://openexchangerates.org/api/latest.json'
-OPEN_EXCHANGE_RATES_APP_ID = '3e53678e72c140b4857dc5bb1deb59dc'
+OPEN_EXCHANGE_RATES_APP_ID = 'f8d574bb309148cbaa0d10c1f9f4adda'
 RATES_CACHE_TIMEOUT = 60 * 60 * 24
 
 AUTO_CONVERT_MONEY = False

--- a/bluebottle/settings/base.py
+++ b/bluebottle/settings/base.py
@@ -285,7 +285,6 @@ SHARED_APPS = (
     'tenant_extras',
     'localflavor',
     'corsheaders',
-    'djmoney_rates',
     'parler',
     'daterange_filter',
     'adminsortable',
@@ -427,9 +426,8 @@ TENANT_APPS = (
 
     'bluebottle.cms',
 
-    # Note: Fixes the incorrect formatting of money values in the back-office
-    # https://github.com/django-money/django-money/issues/232
     'djmoney',
+    'djmoney.contrib.exchange',
     'django_singleton_admin',
     'nested_inline',
     'permissions_widget',
@@ -931,12 +929,11 @@ GEOPOSITION_GOOGLE_MAPS_API_KEY = ''
 STATIC_MAPS_API_KEY = ''
 STATIC_MAPS_API_SECRET = ''
 
-DJANGO_MONEY_RATES = {
-    'DEFAULT_BACKEND': 'djmoney_rates.backends.OpenExchangeBackend',
-    'OPENEXCHANGE_URL': 'http://openexchangerates.org/api/latest.json',
-    'OPENEXCHANGE_APP_ID': '3e53678e72c140b4857dc5bb1deb59dc',
-    'OPENEXCHANGE_BASE_CURRENCY': 'USD',
-}
+# django money settings
+OPEN_EXCHANGE_RATES_URL = 'http://openexchangerates.org/api/latest.json'
+OPEN_EXCHANGE_RATES_APP_ID = '3e53678e72c140b4857dc5bb1deb59dc'
+RATES_CACHE_TIMEOUT = 60 * 60 * 24
+
 AUTO_CONVERT_MONEY = False
 
 LOCKDOWN_URL_EXCEPTIONS = [

--- a/bluebottle/settings/testing.py
+++ b/bluebottle/settings/testing.py
@@ -163,4 +163,4 @@ AXES_CACHE = 'axes_cache'
 STATIC_MAPS_API_KEY = 'someinvalidapikey'
 STATIC_MAPS_API_SECRET = 'fpqFpdo4RY9GDc-xxawF6Ipmp3Y='
 
-DEFAULT_CURRENCY = 'USD'
+DEFAULT_CURRENCY = 'EUR'

--- a/bluebottle/settings/testing.py
+++ b/bluebottle/settings/testing.py
@@ -163,4 +163,4 @@ AXES_CACHE = 'axes_cache'
 STATIC_MAPS_API_KEY = 'someinvalidapikey'
 STATIC_MAPS_API_SECRET = 'fpqFpdo4RY9GDc-xxawF6Ipmp3Y='
 
-
+DEFAULT_CURRENCY = 'USD'

--- a/bluebottle/statistics/statistics.py
+++ b/bluebottle/statistics/statistics.py
@@ -1,12 +1,12 @@
 from django.db.models import Q
 from django.db.models.aggregates import Sum
+from djmoney.contrib.exchange.models import convert_money
 
 from memoize import memoize
 
 from moneyed.classes import Money
 
 from bluebottle.clients import properties
-from bluebottle.utils.exchange_rates import convert
 
 from bluebottle.initiatives.models import Initiative
 from bluebottle.activities.models import Contribution, Activity
@@ -175,7 +175,7 @@ class Statistics(object):
         totals = donations.order_by('amount_currency').values('amount_currency').annotate(total=Sum('amount'))
         amounts = [Money(total['total'], total['amount_currency']) for total in totals]
         if totals:
-            donated = sum([convert(amount, properties.DEFAULT_CURRENCY) for amount in amounts])
+            donated = sum([convert_money(amount, properties.DEFAULT_CURRENCY) for amount in amounts])
         else:
             donated = Money(0, properties.DEFAULT_CURRENCY)
 
@@ -248,7 +248,7 @@ class Statistics(object):
 
         amounts = [Money(total['total'], total['amount_matching_currency']) for total in totals]
         if totals:
-            return sum([convert(amount, properties.DEFAULT_CURRENCY) for amount in amounts])
+            return sum([convert_money(amount, properties.DEFAULT_CURRENCY) for amount in amounts])
         else:
             return Money(0, properties.DEFAULT_CURRENCY)
 
@@ -281,7 +281,7 @@ class Statistics(object):
 
         amounts = [Money(total['total'], total['donation__amount_currency']) for total in totals]
         if totals:
-            donated = sum([convert(amount, properties.DEFAULT_CURRENCY) for amount in amounts])
+            donated = sum([convert_money(amount, properties.DEFAULT_CURRENCY) for amount in amounts])
         else:
             donated = Money(0, properties.DEFAULT_CURRENCY)
 

--- a/bluebottle/test/factory_models/orders.py
+++ b/bluebottle/test/factory_models/orders.py
@@ -3,6 +3,9 @@ import factory
 from bluebottle.orders.models import Order
 from bluebottle.utils.utils import StatusDefinition
 from bluebottle.payments.models import OrderPaymentAction
+
+from djmoney.money import Money
+
 from .accounts import BlueBottleUserFactory
 
 
@@ -11,6 +14,7 @@ class OrderFactory(factory.DjangoModelFactory):
         model = Order
     user = factory.SubFactory(BlueBottleUserFactory)
     status = StatusDefinition.CREATED
+    total = Money(0, 'EUR')
 
 
 class OrderActionFactory(factory.DjangoModelFactory):

--- a/bluebottle/test/factory_models/projects.py
+++ b/bluebottle/test/factory_models/projects.py
@@ -60,4 +60,5 @@ class ProjectFactory(factory.DjangoModelFactory):
     deadline = timezone.now() + timedelta(days=100)
     amount_needed = Money(100, 'EUR')
     amount_asked = Money(100, 'EUR')
+    amount_extra = Money(0, 'EUR')
     allow_overfunding = True

--- a/bluebottle/test/factory_models/rates.py
+++ b/bluebottle/test/factory_models/rates.py
@@ -6,7 +6,7 @@ class ExchangeBackendFactory(factory.DjangoModelFactory):
     class Meta(object):
         model = ExchangeBackend
 
-    name = 'openexchange.org'
+    name = 'openexchangerates.org'
     base_currency = 'USD'
 
 

--- a/bluebottle/test/factory_models/rates.py
+++ b/bluebottle/test/factory_models/rates.py
@@ -1,10 +1,10 @@
 import factory
-from djmoney_rates.models import RateSource, Rate
+from djmoney.contrib.exchange.models import Rate, ExchangeBackend
 
 
-class RateSourceFactory(factory.DjangoModelFactory):
+class ExchangeBackendFactory(factory.DjangoModelFactory):
     class Meta(object):
-        model = RateSource
+        model = ExchangeBackend
 
     name = 'openexchange.org'
     base_currency = 'USD'
@@ -14,4 +14,4 @@ class RateFactory(factory.DjangoModelFactory):
     class Meta(object):
         model = Rate
 
-    source = factory.SubFactory(RateSourceFactory)
+    backend = factory.SubFactory(ExchangeBackendFactory)

--- a/bluebottle/test/test_runner.py
+++ b/bluebottle/test/test_runner.py
@@ -41,7 +41,7 @@ class MultiTenantRunner(DiscoverSlowestTestsRunner, InitProjectDataMixin):
         self.init_projects()
 
         try:
-            backend = ExchangeBackendFactory.create(base_currency='USD')
+            backend = ExchangeBackendFactory.create(base_currency='EUR')
             RateFactory.create(backend=backend, currency='USD', value=1)
             RateFactory.create(backend=backend, currency='EUR', value=1.5)
             RateFactory.create(backend=backend, currency='XOF', value=1000)

--- a/bluebottle/test/test_runner.py
+++ b/bluebottle/test/test_runner.py
@@ -5,7 +5,7 @@ from django_slowtests.testrunner import DiscoverSlowestTestsRunner
 
 from tenant_schemas.utils import get_tenant_model
 
-from bluebottle.test.factory_models.rates import RateSourceFactory, RateFactory
+from bluebottle.test.factory_models.rates import RateFactory, ExchangeBackendFactory
 from bluebottle.test.utils import InitProjectDataMixin
 
 
@@ -41,13 +41,13 @@ class MultiTenantRunner(DiscoverSlowestTestsRunner, InitProjectDataMixin):
         self.init_projects()
 
         try:
-            rate_source = RateSourceFactory.create(base_currency='USD')
-            RateFactory.create(source=rate_source, currency='USD', value=1)
-            RateFactory.create(source=rate_source, currency='EUR', value=1.5)
-            RateFactory.create(source=rate_source, currency='XOF', value=1000)
-            RateFactory.create(source=rate_source, currency='NGN', value=500)
-            RateFactory.create(source=rate_source, currency='UGX', value=5000)
-            RateFactory.create(source=rate_source, currency='KES', value=100)
+            backend = ExchangeBackendFactory.create(base_currency='USD')
+            RateFactory.create(backend=backend, currency='USD', value=1)
+            RateFactory.create(backend=backend, currency='EUR', value=1.5)
+            RateFactory.create(backend=backend, currency='XOF', value=1000)
+            RateFactory.create(backend=backend, currency='NGN', value=500)
+            RateFactory.create(backend=backend, currency='UGX', value=5000)
+            RateFactory.create(backend=backend, currency='KES', value=100)
         except IntegrityError:
             pass
 

--- a/bluebottle/utils/admin.py
+++ b/bluebottle/utils/admin.py
@@ -16,6 +16,7 @@ from django.http import HttpResponseRedirect
 from django.template import loader
 from django.template.response import TemplateResponse
 from django_singleton_admin.admin import SingletonAdmin
+from djmoney.contrib.exchange.models import convert_money
 from moneyed import Money
 from parler.admin import TranslatableAdmin
 
@@ -24,7 +25,6 @@ from bluebottle.clients import properties
 from bluebottle.fsm import TransitionNotPossible
 from bluebottle.members.models import Member, CustomMemberFieldSettings, CustomMemberField
 from bluebottle.projects.models import CustomProjectFieldSettings, Project, CustomProjectField
-from bluebottle.utils.exchange_rates import convert
 from bluebottle.utils.forms import FSMModelForm
 from bluebottle.utils.forms import TransitionConfirmationForm
 from .models import Language, TranslationPlatformSettings
@@ -155,7 +155,7 @@ class TotalAmountAdminChangeList(ChangeList):
         ).order_by()
 
         amounts = [Money(total['total'], total[currency_column]) for total in totals]
-        amounts = [convert(amount, properties.DEFAULT_CURRENCY) for amount in amounts]
+        amounts = [convert_money(amount, properties.DEFAULT_CURRENCY) for amount in amounts]
         self.total = sum(amounts) or Money(0, properties.DEFAULT_CURRENCY)
 
 

--- a/bluebottle/utils/exchange_rates.py
+++ b/bluebottle/utils/exchange_rates.py
@@ -1,6 +1,6 @@
-from djmoney_rates.utils import convert_money
+from djmoney.contrib.exchange.models import convert_money
 
 
 def convert(money, currency):
     """ Convert money object `money` to `currency`."""
-    return convert_money(money.amount, money.currency, currency)
+    return convert_money(money, currency)

--- a/bluebottle/utils/models.py
+++ b/bluebottle/utils/models.py
@@ -11,7 +11,6 @@ from operator import attrgetter
 from parler.models import TranslatableModel, TranslatedFields
 
 import bluebottle.utils.monkey_patch_corsheaders  # noqa
-import bluebottle.utils.monkey_patch_dj_money_rates  # noqa
 import bluebottle.utils.monkey_patch_django_elasticsearch_dsl  # noqa
 import bluebottle.utils.monkey_patch_migration  # noqa
 import bluebottle.utils.monkey_patch_money_readonly_fields  # noqa

--- a/bluebottle/utils/monkey_patch_dj_money_rates.py
+++ b/bluebottle/utils/monkey_patch_dj_money_rates.py
@@ -1,6 +1,0 @@
-from memoize import memoize
-import djmoney_rates.utils
-
-
-djmoney_rates.utils.get_rate = memoize()(djmoney_rates.utils.get_rate)
-djmoney_rates.utils.get_rate_source = memoize()(djmoney_rates.utils.get_rate_source)

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ install_requires = [
     'django-map-widgets==0.2.2',
     'django-memoize==2.1.0',
     'django-modeltranslation==0.12.1',
-    'django-money==0.14',
+    'django-money==0.15.1',
     'django-parler==1.9.2',
     'django-permissions-widget==1.5.1',
     'django_polymorphic==1.2',
@@ -124,7 +124,6 @@ install_requires = [
     'django-fluent-contents @ git+https://github.com/onepercentclub/django-fluent-contents.git@741ffae615a4afed01388a202709ed9a5b60e80f#egg=django-fluent-contents-1.2.1-741ffae6',
     'django-bb-salesforce @ git+https://github.com/onepercentclub/django-bb-salesforce.git@1.2.2#egg=django-bb-salesforce-1.2.2',
     'django-taggit-autocomplete-modified @ git+https://github.com/onepercentclub/django-taggit-autocomplete-modified.git@8e7fbc2deae2f1fbb31b574bc8819d9ae7c644d6#egg=django-taggit-autocomplete-modified-0.1.1b1',
-    'django-money-rates @ git+https://github.com/skada/django-money-rates@aeb2edf240471fac64f9cdf71e34f91d632f1b86#egg=django-money-rates-0.3.1-github',
 ]
 
 tests_requires = [


### PR DESCRIPTION
Money rates are now part of django-mone and it is not Python 3 compatible

If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
