### PR TITLE
Also mark new applicants succeeded when an assignment is succeeded

### DIFF
--- a/bluebottle/assignments/models.py
+++ b/bluebottle/assignments/models.py
@@ -136,6 +136,10 @@ class Assignment(Activity):
         return self.contributions.instance_of(Applicant).filter(status__in=accepted_states)
 
     @property
+    def new_applicants(self):
+        return self.contributions.instance_of(Applicant).filter(status='new')
+
+    @property
     def applicants(self):
         return self.contributions.instance_of(Applicant)
 

--- a/bluebottle/assignments/periodic_tasks.py
+++ b/bluebottle/assignments/periodic_tasks.py
@@ -27,9 +27,6 @@ class AssignmentStartOnDateTask(ModelPeriodicTask):
         TransitionEffect('start', conditions=[
             AssignmentStateMachine.has_accepted_applicants
         ]),
-        TransitionEffect('expire', conditions=[
-            AssignmentStateMachine.has_no_accepted_applicants
-        ]),
     ]
 
     def __unicode__(self):
@@ -52,9 +49,6 @@ class AssignmentStartDeadlineTask(ModelPeriodicTask):
         TransitionEffect('start', conditions=[
             AssignmentStateMachine.has_accepted_applicants
         ]),
-        TransitionEffect('expire', conditions=[
-            AssignmentStateMachine.has_no_accepted_applicants
-        ]),
     ]
 
     def __unicode__(self):
@@ -76,10 +70,10 @@ class AssignmentFinishedDeadlineTask(ModelPeriodicTask):
 
     effects = [
         TransitionEffect('succeed', conditions=[
-            AssignmentStateMachine.has_accepted_applicants
+            AssignmentStateMachine.has_new_or_accepted_applicants
         ]),
         TransitionEffect('expire', conditions=[
-            AssignmentStateMachine.has_no_accepted_applicants
+            AssignmentStateMachine.has_no_new_or_accepted_applicants
         ]),
     ]
 
@@ -102,10 +96,10 @@ class AssignmentFinishedOnDateTask(ModelPeriodicTask):
 
     effects = [
         TransitionEffect('succeed', conditions=[
-            AssignmentStateMachine.has_accepted_applicants
+            AssignmentStateMachine.has_new_or_accepted_applicants
         ]),
         TransitionEffect('expire', conditions=[
-            AssignmentStateMachine.has_no_accepted_applicants
+            AssignmentStateMachine.has_no_new_or_accepted_applicants
         ]),
     ]
 
@@ -127,10 +121,10 @@ class AssignmentRegistrationOnDateTask(ModelPeriodicTask):
 
     effects = [
         TransitionEffect('lock', conditions=[
-            AssignmentStateMachine.has_accepted_applicants
+            AssignmentStateMachine.has_new_or_accepted_applicants
         ]),
         TransitionEffect('expire', conditions=[
-            AssignmentStateMachine.has_no_accepted_applicants
+            AssignmentStateMachine.has_no_new_or_accepted_applicants
         ]),
     ]
 

--- a/bluebottle/assignments/states.py
+++ b/bluebottle/assignments/states.py
@@ -58,6 +58,14 @@ class AssignmentStateMachine(ActivityStateMachine):
         """there are no accepted applicants"""
         return len(self.instance.accepted_applicants) == 0
 
+    def has_new_or_accepted_applicants(self):
+        """there are accepted applicants"""
+        return len(self.instance.accepted_applicants) > 0 or len(self.instance.new_applicants) > 0
+
+    def has_no_new_or_accepted_applicants(self):
+        """there are no accepted applicants"""
+        return len(self.instance.accepted_applicants) == 0 and len(self.instance.new_applicants) == 0
+
     def is_not_full(self):
         """the task is not full"""
         return self.instance.capacity > len(self.instance.accepted_applicants)
@@ -211,6 +219,7 @@ class AssignmentStateMachine(ActivityStateMachine):
         automatic=True,
         effects=[
             RelatedTransitionEffect('accepted_applicants', 'succeed'),
+            RelatedTransitionEffect('new_applicants', 'succeed'),
             NotificationEffect(AssignmentCompletedMessage)
         ]
     )
@@ -333,7 +342,8 @@ class ApplicantStateMachine(ContributionStateMachine):
         description=_("User applied to join the task."),
         effects=[
             NotificationEffect(AssignmentApplicationMessage),
-            FollowActivityEffect
+            FollowActivityEffect,
+            TransitionEffect('succeed', conditions=[assignment_is_finished])
         ]
     )
 

--- a/bluebottle/assignments/triggers.py
+++ b/bluebottle/assignments/triggers.py
@@ -43,14 +43,14 @@ class DateChangedTrigger(ModelChangedTrigger):
             'succeed',
             conditions=[
                 AssignmentStateMachine.should_finish,
-                AssignmentStateMachine.has_accepted_applicants
+                AssignmentStateMachine.has_new_or_accepted_applicants
             ]
         ),
         TransitionEffect(
             'expire',
             conditions=[
                 AssignmentStateMachine.should_finish,
-                AssignmentStateMachine.has_no_accepted_applicants
+                AssignmentStateMachine.has_no_new_or_accepted_applicants
             ]
         ),
         TransitionEffect(


### PR DESCRIPTION
If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
