### PR TITLE
Convert from and to any currency

### DIFF
--- a/bluebottle/funding/models.py
+++ b/bluebottle/funding/models.py
@@ -10,7 +10,6 @@ from babel.numbers import get_currency_name
 from future.utils import python_2_unicode_compatible
 
 from bluebottle.clients import properties
-from djmoney.contrib.exchange.models import convert_money
 
 from bluebottle.fsm.triggers import TriggerMixin
 
@@ -30,6 +29,7 @@ from tenant_schemas.postgresql_backend.base import FakeTenant
 from bluebottle.activities.models import Activity, Contribution
 from bluebottle.funding.validators import KYCReadyValidator, DeadlineValidator, BudgetLineValidator, TargetValidator
 from bluebottle.files.fields import ImageField, PrivateDocumentField
+from bluebottle.utils.exchange_rates import convert
 from bluebottle.utils.fields import MoneyField
 from bluebottle.utils.models import BasePlatformSettings, AnonymizationMixin, ValidatedModelMixin
 
@@ -267,7 +267,7 @@ class Funding(Activity):
             currency = 'EUR'
         total = self.amount_donated
         if self.amount_matching:
-            total += convert_money(
+            total += convert(
                 self.amount_matching,
                 currency
             )
@@ -404,7 +404,7 @@ class Fundraiser(AnonymizationMixin, models.Model):
             donations.values('amount_currency').annotate(Sum('amount')).order_by()
         ]
 
-        totals = [convert_money(amount, self.amount.currency) for amount in totals]
+        totals = [convert(amount, self.amount.currency) for amount in totals]
 
         return sum(totals) or Money(0, self.amount.currency)
 

--- a/bluebottle/funding/tests/test_admin.py
+++ b/bluebottle/funding/tests/test_admin.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from datetime import timedelta
 
 from django.urls import reverse
@@ -104,6 +105,20 @@ class DonationAdminTestCase(BluebottleAdminTestCase):
             bank_account=bank_account
         )
         self.admin_url = reverse('admin:funding_donation_changelist')
+
+    def test_donation_total(self):
+        for donation in DonationFactory.create_batch(
+            2,
+            activity=self.funding,
+            amount=Money(100, 'NGN')
+        ):
+            PledgePaymentFactory.create(donation=donation)
+
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.admin_url)
+        self.assertTrue(
+            'Total amount:  <b>0.60 €</b>' in response.content
+        )
 
     def test_donation_admin_pledge_filter(self):
         for donation in DonationFactory.create_batch(2, activity=self.funding):

--- a/bluebottle/funding/tests/test_admin.py
+++ b/bluebottle/funding/tests/test_admin.py
@@ -117,7 +117,7 @@ class DonationAdminTestCase(BluebottleAdminTestCase):
         self.client.force_login(self.superuser)
         response = self.client.get(self.admin_url)
         self.assertTrue(
-            'Total amount:  <b>0.60 €</b>' in response.content
+            u'Total amount:  <b>0.60 €</b>'.encode('utf-8') in response.content
         )
 
     def test_donation_admin_pledge_filter(self):

--- a/bluebottle/initiatives/models.py
+++ b/bluebottle/initiatives/models.py
@@ -7,7 +7,6 @@ from django.db.models.deletion import SET_NULL
 from django.template.defaultfilters import slugify
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
-from djmoney.contrib.exchange.models import convert_money
 from future.utils import python_2_unicode_compatible
 from moneyed import Money
 from multiselectfield import MultiSelectField
@@ -20,6 +19,7 @@ from bluebottle.geo.models import Geolocation, Location
 from bluebottle.initiatives.messages import AssignedReviewerMessage
 from bluebottle.initiatives.validators import UniqueTitleValidator
 from bluebottle.organizations.models import Organization, OrganizationContact
+from bluebottle.utils.exchange_rates import convert
 from bluebottle.utils.models import BasePlatformSettings, ValidatedModelMixin, AnonymizationMixin
 from bluebottle.utils.utils import get_current_host, get_current_language, clean_html
 
@@ -157,7 +157,7 @@ class Initiative(TriggerMixin, AnonymizationMixin, ValidatedModelMixin, models.M
             'contributions': sum(stat['count'] for stat in stats),
             'hours': sum(stat['hours'] or 0 for stat in stats if 'hours' in stat),
             'amount': sum(
-                convert_money(Money(stat['amount']['amount'], stat['amount']['currency']), currency).amount
+                convert(Money(stat['amount']['amount'], stat['amount']['currency']), currency).amount
                 for stat in stats if 'amount' in stat
             ),
         }

--- a/bluebottle/settings/base.py
+++ b/bluebottle/settings/base.py
@@ -863,6 +863,7 @@ DONATION_AMOUNTS = {
 }
 
 DEFAULT_CURRENCY = 'EUR'
+BASE_CURRENCY = 'USD'
 
 # By default we do not show suggestion on the start-project page
 PROJECT_SUGGESTIONS = False

--- a/bluebottle/statistics/statistics.py
+++ b/bluebottle/statistics/statistics.py
@@ -1,7 +1,6 @@
 from builtins import object
 from django.db.models import Q
 from django.db.models.aggregates import Sum
-from djmoney.contrib.exchange.models import convert_money
 
 from memoize import memoize
 
@@ -16,6 +15,7 @@ from bluebottle.events.models import Event, Participant
 from bluebottle.assignments.models import Assignment, Applicant
 from bluebottle.funding.models import Donation, Funding
 from bluebottle.funding_pledge.models import PledgePayment
+from bluebottle.utils.exchange_rates import convert
 
 
 class Statistics(object):
@@ -175,7 +175,7 @@ class Statistics(object):
         totals = donations.order_by('amount_currency').values('amount_currency').annotate(total=Sum('amount'))
         amounts = [Money(total['total'], total['amount_currency']) for total in totals]
         if totals:
-            donated = sum([convert_money(amount, properties.DEFAULT_CURRENCY) for amount in amounts])
+            donated = sum([convert(amount, properties.DEFAULT_CURRENCY) for amount in amounts])
         else:
             donated = Money(0, properties.DEFAULT_CURRENCY)
 
@@ -243,7 +243,7 @@ class Statistics(object):
 
         amounts = [Money(total['total'], total['amount_matching_currency']) for total in totals]
         if totals:
-            return sum([convert_money(amount, properties.DEFAULT_CURRENCY) for amount in amounts])
+            return sum([convert(amount, properties.DEFAULT_CURRENCY) for amount in amounts])
         else:
             return Money(0, properties.DEFAULT_CURRENCY)
 
@@ -276,7 +276,7 @@ class Statistics(object):
 
         amounts = [Money(total['total'], total['donation__amount_currency']) for total in totals]
         if totals:
-            donated = sum([convert_money(amount, properties.DEFAULT_CURRENCY) for amount in amounts])
+            donated = sum([convert(amount, properties.DEFAULT_CURRENCY) for amount in amounts])
         else:
             donated = Money(0, properties.DEFAULT_CURRENCY)
 

--- a/bluebottle/test/utils.py
+++ b/bluebottle/test/utils.py
@@ -233,7 +233,6 @@ class override_properties(object):
     def __enter__(self):
         self.old_properties = properties.tenant_properties
         properties.tenant_properties = self.properties
-        print properties.DEFAULT_CURRENCY, '!!!!'
 
     def __exit__(self, *args):
         properties.tenant_properties = self.old_properties

--- a/bluebottle/test/utils.py
+++ b/bluebottle/test/utils.py
@@ -233,6 +233,7 @@ class override_properties(object):
     def __enter__(self):
         self.old_properties = properties.tenant_properties
         properties.tenant_properties = self.properties
+        print properties.DEFAULT_CURRENCY, '!!!!'
 
     def __exit__(self, *args):
         properties.tenant_properties = self.old_properties

--- a/bluebottle/utils/admin.py
+++ b/bluebottle/utils/admin.py
@@ -21,7 +21,6 @@ from django.template.response import TemplateResponse
 from django_singleton_admin.admin import SingletonAdmin
 from django.utils.encoding import smart_str
 
-from djmoney.contrib.exchange.models import convert_money
 from moneyed import Money
 from parler.admin import TranslatableAdmin
 
@@ -31,6 +30,7 @@ from bluebottle.fsm import TransitionNotPossible
 from bluebottle.members.models import Member, CustomMemberFieldSettings, CustomMemberField
 from bluebottle.utils.forms import FSMModelForm
 from bluebottle.utils.forms import TransitionConfirmationForm
+from bluebottle.utils.exchange_rates import convert
 from .models import Language, TranslationPlatformSettings
 
 
@@ -156,7 +156,7 @@ class TotalAmountAdminChangeList(ChangeList):
         ).order_by()
 
         amounts = [Money(total['total'], total[currency_column]) for total in totals]
-        amounts = [convert_money(amount, properties.DEFAULT_CURRENCY) for amount in amounts]
+        amounts = [convert(amount, properties.DEFAULT_CURRENCY) for amount in amounts]
         self.total = sum(amounts) or Money(0, properties.DEFAULT_CURRENCY)
 
 

--- a/bluebottle/utils/exchange_rates.py
+++ b/bluebottle/utils/exchange_rates.py
@@ -4,7 +4,13 @@ from djmoney.contrib.exchange.models import convert_money
 
 def convert(money, currency):
     """ Convert money object `money` to `currency`."""
-    if money.currency != settings.BASE_CURRENCY and currency != settings.BASE_CURRENCY:
+    if hasattr(currency, 'code'):
+        currency = currency.code
+
+    if money.currency.code == currency:
+        return money
+
+    if money.currency.code != settings.BASE_CURRENCY and currency != settings.BASE_CURRENCY:
         money = convert_money(money, settings.BASE_CURRENCY)
 
     return convert_money(money, currency)

--- a/bluebottle/utils/exchange_rates.py
+++ b/bluebottle/utils/exchange_rates.py
@@ -1,6 +1,10 @@
+from django.conf import settings
 from djmoney.contrib.exchange.models import convert_money
 
 
 def convert(money, currency):
     """ Convert money object `money` to `currency`."""
+    if money.currency != settings.BASE_CURRENCY and currency != settings.BASE_CURRENCY:
+        money = convert_money(money, settings.BASE_CURRENCY)
+
     return convert_money(money, currency)


### PR DESCRIPTION
So far it was only possible to convert to or from the default usd
currency.

We added a function that first converts to the base currency, and than
does the acctual conversion. This way it will always work.

If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
