### PR TITLE
Fix unicode error in mail sending

### DIFF
--- a/bluebottle/utils/email_backend.py
+++ b/bluebottle/utils/email_backend.py
@@ -48,7 +48,7 @@ class TenantAwareBackend(EmailBackend):
         if not email_message.recipients():
             return False
         try:
-            message_string = email_message.message().as_string()
+            message_string = email_message.message().as_bytes()
             signature = b""
             try:
                 signature = dkim.sign(message_string,

--- a/bluebottle/utils/email_backend.py
+++ b/bluebottle/utils/email_backend.py
@@ -51,7 +51,7 @@ class TenantAwareBackend(EmailBackend):
             message_string = email_message.message().as_string()
             signature = b""
             try:
-                signature = dkim.sign(message_string.encode('utf-8'),
+                signature = dkim.sign(message_string,
                                       properties.DKIM_SELECTOR,
                                       properties.DKIM_DOMAIN,
                                       properties.DKIM_PRIVATE_KEY)
@@ -60,7 +60,7 @@ class TenantAwareBackend(EmailBackend):
 
             self.connection.sendmail(
                 email_message.from_email, email_message.recipients(),
-                signature.decode() + message_string)
+                signature + message_string)
         except Exception:
             if not self.fail_silently:
                 raise

--- a/bluebottle/utils/tests/test_unit.py
+++ b/bluebottle/utils/tests/test_unit.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from builtins import str
 from builtins import object
 import dkim
@@ -306,7 +307,7 @@ class TestTenantAwareMailServer(unittest.TestCase):
             properties.DKIM_PRIVATE_KEY = DKIM_PRIVATE_KEY
 
             be = TenantAwareBackend()
-            msg = EmailMultiAlternatives(subject="test", body="test",
+            msg = EmailMultiAlternatives(subject=u"test€", body=u"test€",
                                          to=["test@example.com"])
 
             be.open()
@@ -326,8 +327,8 @@ class TestTenantAwareMailServer(unittest.TestCase):
                 )
             )
 
-            self.assertTrue(signed_msg.find("d=testserver") >= 0)
-            self.assertTrue(signed_msg.find("s=key2") >= 0)
+            self.assertTrue(signed_msg.find(b"d=testserver") >= 0)
+            self.assertTrue(signed_msg.find(b"s=key2") >= 0)
             self.assertTrue(dkim_check, "Email should be signed by tenant")
 
     @override_settings(


### PR DESCRIPTION
If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
