### PR TITLE
Also count matching total for open and partial activities

### DIFF
--- a/bluebottle/statistics/statistics.py
+++ b/bluebottle/statistics/statistics.py
@@ -236,7 +236,7 @@ class Statistics(object):
         """ Total amount matched on realized (done and incomplete) activities """
         totals = Funding.objects.filter(
             self.date_filter('transition_date'),
-            status='succeeded'
+            status__in=['succeeded', 'open', 'partial']
         ).filter(
             amount_matching__gt=0
         ).values('amount_matching_currency').annotate(total=Sum('amount_matching'))

--- a/bluebottle/statistics/tests/test_unit.py
+++ b/bluebottle/statistics/tests/test_unit.py
@@ -351,6 +351,8 @@ class FundingStatisticsTest(StatisticsTest):
         self.funding.states.approve(save=True)
 
     def test_open(self):
+        self.funding.amount_matching = Money(100, 'EUR')
+        self.funding.save()
         self.assertEqual(
             self.stats.activities_online, 1
         )
@@ -362,6 +364,9 @@ class FundingStatisticsTest(StatisticsTest):
         )
         self.assertEqual(
             self.stats.people_involved, 1
+        )
+        self.assertEqual(
+            self.stats.amount_matched, Money(100, 'EUR')
         )
 
     def test_succeeded(self):


### PR DESCRIPTION
If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
