### PR TITLE
Check/test that funding activities get auto submitted or not.

### DIFF
--- a/bluebottle/funding/effects.py
+++ b/bluebottle/funding/effects.py
@@ -1,3 +1,4 @@
+from bluebottle.fsm.state import TransitionNotPossible
 from future.utils import python_2_unicode_compatible
 
 import datetime
@@ -159,7 +160,10 @@ class SubmitConnectedActivitiesEffect(Effect):
         for funding in self.instance.funding_set.filter(
                 status__in=('draft', 'needs_work')
         ):
-            funding.states.submit(save=True)
+            try:
+                funding.states.submit(save=True)
+            except TransitionNotPossible:
+                pass
 
     def __str__(self):
         return _('Submit connected activities')

--- a/bluebottle/funding_stripe/tests/test_states.py
+++ b/bluebottle/funding_stripe/tests/test_states.py
@@ -155,13 +155,37 @@ class StripePayoutAccountStateMachineTests(BluebottleTestCase):
         })
         with patch('stripe.Account.retrieve', return_value=self.stripe_account):
             self.account.save()
+            self.bank_account = ExternalAccountFactory.create(connect_account=self.account)
 
     def test_initial(self):
         self.assertEqual(self.account.status, 'new')
 
-    def test_accept(self):
+    def test_verify(self):
         self.account.states.verify(save=True)
         self.assertEqual(self.account.status, 'verified')
+
+    def test_verify_submit_activities(self):
+        initiative = InitiativeFactory.create()
+        initiative.states.submit()
+        initiative.states.approve(save=True)
+        complete_funding = FundingFactory.create(
+            bank_account=self.bank_account,
+            initiative=initiative,
+            target=Money(1000, 'EUR')
+        )
+        BudgetLineFactory.create(activity=complete_funding)
+
+        incomplete_funding = FundingFactory.create(
+            bank_account=self.bank_account,
+            initiative=initiative,
+            target=Money(1000, 'EUR')
+        )
+        self.account.states.verify(save=True)
+        self.assertEqual(self.account.status, 'verified')
+        incomplete_funding.refresh_from_db()
+        self.assertEqual(incomplete_funding.status, 'draft')
+        complete_funding.refresh_from_db()
+        self.assertEqual(complete_funding.status, 'submitted')
 
     def test_accept_mail(self):
         self.account.states.verify(save=True)


### PR DESCRIPTION
If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
