### PR TITLE
Delay import to allow startup

### DIFF
--- a/bluebottle/clients/__init__.py
+++ b/bluebottle/clients/__init__.py
@@ -5,8 +5,6 @@ from threading import local
 from django.conf import settings
 from django.utils._os import safe_join
 
-from tenant_schemas.postgresql_backend.base import FakeTenant
-
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +33,8 @@ class TenantProperties(local):
                      self.tenant_properties)
 
         except (ImportError, AttributeError, IOError):
+            from tenant_schemas.postgresql_backend.base import FakeTenant
+
             if not isinstance(tenant, FakeTenant):
                 logger.debug('No tenant properties found for: {0}'.format(tenant.client_name))
 


### PR DESCRIPTION
Importing FakeTenant from `__init__` causes AppRegistryNotReady
exception because apps should not be imported until after
AppConfig.ready.
