### PR TITLE
Fix rendering of timecontribution transitions.

### DIFF
--- a/bluebottle/activities/effects.py
+++ b/bluebottle/activities/effects.py
@@ -35,8 +35,7 @@ class SetContributionDateEffect(Effect):
     "Set the contribution date"
 
     conditions = []
-    title = _('Set contribution date')
-    template = 'admin/set_contribution_date.html'
+    display = False
 
     def pre_save(self, **kwargs):
         self.instance.start = now()

--- a/bluebottle/activities/states.py
+++ b/bluebottle/activities/states.py
@@ -293,7 +293,7 @@ class ContributionStateMachine(ModelStateMachine):
     )
 
     succeed = Transition(
-        new,
+        [new, failed],
         succeeded,
         name=_('succeeded'),
         description=_("The contribution succeeded. It will be visible in reports."),

--- a/bluebottle/fsm/admin.py
+++ b/bluebottle/fsm/admin.py
@@ -68,8 +68,8 @@ class StateMachineAdminMixin(object):
                         self.save_form(request, form, change=True)
                         effects += form.instance.execute_triggers(user=request.user, send_messages=send_messages)
 
-            if effects:
-                rendered_effects = get_effects(effects)
+            rendered_effects = get_effects(effects)
+            if rendered_effects:
 
                 cancel_link = reverse(
                     'admin:{}_{}_change'.format(

--- a/bluebottle/initiatives/serializers.py
+++ b/bluebottle/initiatives/serializers.py
@@ -20,6 +20,7 @@ from bluebottle.clients import properties
 from bluebottle.files.models import Image
 from bluebottle.files.models import RelatedImage
 from bluebottle.files.serializers import ImageSerializer, ImageField
+from bluebottle.funding.models import MoneyContribution
 from bluebottle.geo.models import Geolocation, Location
 from bluebottle.geo.serializers import TinyPointSerializer
 from bluebottle.initiatives.models import Initiative, InitiativePlatformSettings
@@ -29,6 +30,7 @@ from bluebottle.organizations.models import Organization, OrganizationContact
 from bluebottle.fsm.serializers import (
     AvailableTransitionsField, TransitionSerializer
 )
+from bluebottle.time_based.models import TimeContribution
 from bluebottle.utils.exchange_rates import convert
 from bluebottle.utils.fields import (
     SafeField,
@@ -168,7 +170,7 @@ class InitiativeSerializer(NoCommitMixin, ModelSerializer):
 
         contributions = Contribution.objects.filter(
             contributor__activity__initiative=obj, status='succeeded'
-        )
+        ).instance_of(TimeContribution, MoneyContribution)
 
         stats = contributions.aggregate(
             hours=Sum('timecontribution__value'),

--- a/bluebottle/notifications/templates/admin/notification_effect.html
+++ b/bluebottle/notifications/templates/admin/notification_effect.html
@@ -10,7 +10,7 @@
         {% endblocktrans %}
 
         {% if recipients|length > 1 %}
-            {% blocktrans with extra=effects|length|add:"-1" %}
+            {% blocktrans with extra=recipients|length|add:"-1" %}
                 and {{ extra }} others 
             {% endblocktrans %}
         {% endif %}

--- a/bluebottle/time_based/effects.py
+++ b/bluebottle/time_based/effects.py
@@ -1,12 +1,13 @@
-from datetime import datetime, date
+from datetime import datetime, date, timedelta
 
 from dateutil.relativedelta import relativedelta
 
 from django.utils.translation import ugettext as _
-from django.utils.timezone import now, get_current_timezone
+from django.utils.timezone import get_current_timezone
 
 from bluebottle.fsm.effects import Effect
 from bluebottle.time_based.models import TimeContribution
+from django.template.loader import render_to_string
 
 
 class CreateDateParticipationEffect(Effect):
@@ -19,7 +20,7 @@ class CreateDateParticipationEffect(Effect):
             end = activity.start + activity.duration
             contribution = TimeContribution(
                 contributor=self.instance,
-                value=activity.duration,
+                value=activity.duration + (activity.preparation or timedelta()),
                 start=activity.start,
                 end=end
             )
@@ -34,27 +35,46 @@ class CreatePeriodParticipationEffect(Effect):
         tz = get_current_timezone()
         activity = self.instance.activity
 
-        start = self.instance.current_period or activity.start or now()
+        if activity.duration_period:
+            if activity.duration_period == 'overall':
+                # Just create a contribution for the full period
+                start = activity.start or date.today()
+                end = activity.deadline if hasattr(activity, 'deadline') else None
 
-        if activity.duration_period == 'overall':
-            end = activity.deadline if hasattr(activity, 'deadline') else None
-        elif activity.duration_period:
-            end = start + relativedelta(**{activity.duration_period: 1})
-        else:
-            end = start
+                TimeContribution.objects.create(
+                    contributor=self.instance,
+                    value=activity.duration,
+                    start=tz.localize(datetime.combine(start, datetime.min.time())),
+                    end=tz.localize(datetime.combine(end, datetime.min.time())) if end else None,
+                )
 
-        self.instance.current_period = end
-        self.instance.save()
+            elif activity.duration_period:
+                if self.instance.current_period or not activity.start:
+                    # Use today if we already have previous contributions
+                    # or when we create a new contribution and now start
+                    start = date.today()
+                else:
+                    # The first contribution should start on the start
+                    start = activity.start
 
-        if start != end:
-            contribution = TimeContribution(
-                contributor=self.instance,
-                value=activity.duration,
-                start=tz.localize(datetime.combine(start, datetime.min.time())),
-                end=tz.localize(datetime.combine(end, datetime.max.time())) if end else None,
-            )
+                # Calculate the next end
+                end = start + relativedelta(**{activity.duration_period: 1})
+                if activity.deadline and end > activity.deadline:
+                    # the end is passed the deadline
+                    end = activity.deadline
 
-            contribution.save()
+                # Update the current_period
+                self.instance.current_period = end
+                self.instance.save()
+
+                if not activity.deadline or start < activity.deadline:
+                    # Only when the deadline is not passed, create the new contribution
+                    TimeContribution.objects.create(
+                        contributor=self.instance,
+                        value=activity.duration,
+                        start=tz.localize(datetime.combine(start, datetime.min.time())),
+                        end=tz.localize(datetime.combine(end, datetime.min.time())) if end else None,
+                    )
 
     def __str__(self):
         return _('Create contribution')
@@ -82,3 +102,64 @@ class ClearDeadlineEffect(Effect):
 
     def pre_save(self, **kwargs):
         self.instance.deadline = None
+
+
+class RescheduleDurationsEffect(Effect):
+    display = False
+
+    def post_save(self, **kwargs):
+        if self.instance.start:
+            self.instance.durations.update(
+                start=self.instance.start,
+                end=self.instance.start + self.instance.duration,
+                value=self.instance.duration + (self.instance.preparation or timedelta())
+            )
+
+
+class BaseActiveDurationsTransitionEffect(Effect):
+    display = True
+    template = 'admin/transition_durations.html'
+
+    @classmethod
+    def render(cls, effects):
+        effect = effects[0]
+        users = [duration.contributor.user for duration in effect.instance.active_durations]
+        print(effect.transition)
+
+        context = {
+            'users': users,
+            'transition': cls.transition.name
+        }
+        return render_to_string(cls.template, context)
+
+    @property
+    def is_valid(self):
+        return (
+            super().is_valid and
+            any(
+                self.transition in duration.states.possible_transitions() for
+                duration in self.instance.active_durations
+            )
+        )
+
+    def pre_save(self, effects):
+        self.transitioned_durations = []
+        for duration in self.instance.active_durations:
+            if self.transition in duration.states.possible_transitions():
+                self.transitioned_durations.append(duration)
+                self.transition.execute(duration.states)
+
+    def post_save(self):
+        for duration in self.transitioned_durations:
+            duration.save()
+
+
+def ActiveDurationsTransitionEffect(transition, conditions=None):
+    _transition = transition
+    _conditions = conditions or []
+
+    class _ActiveDurationsTransitionEffect(BaseActiveDurationsTransitionEffect):
+        transition = _transition
+        conditions = _conditions
+
+    return _ActiveDurationsTransitionEffect

--- a/bluebottle/time_based/models.py
+++ b/bluebottle/time_based/models.py
@@ -317,6 +317,10 @@ class PeriodParticipant(Participant, Contributor):
     def current_contribution(self):
         return self.contributions.get(status='new')
 
+    @property
+    def finished_contributions(self):
+        return self.contributions.filter(end__lt=timezone.now())
+
     class JSONAPIMeta:
         resource_name = 'contributors/time-based/period-participants'
 

--- a/bluebottle/time_based/states.py
+++ b/bluebottle/time_based/states.py
@@ -101,6 +101,7 @@ class TimeBasedStateMachine(ActivityStateMachine):
             'and will continue to count in the reporting.'
         ),
         automatic=False,
+        hide_from_admin=True,
     )
 
 
@@ -195,7 +196,11 @@ class ParticipantStateMachine(ContributorStateMachine):
 
     def activity_is_open(self):
         """task is open"""
-        return self.instance.activity.status == ActivityStateMachine.open.value
+        return self.instance.activity.status in (
+            TimeBasedStateMachine.open.value,
+            TimeBasedStateMachine.running.value,
+            TimeBasedStateMachine.full.value
+        )
 
     initiate = Transition(
         EmptyState(),

--- a/bluebottle/time_based/states.py
+++ b/bluebottle/time_based/states.py
@@ -125,7 +125,7 @@ class DateStateMachine(TimeBasedStateMachine):
 @register(PeriodActivity)
 class PeriodStateMachine(TimeBasedStateMachine):
     def can_succeed(self):
-        return self.instance.duration_period != 'overall' and len(self.instance.active_participants) > 0
+        return len(self.instance.active_participants) > 0
 
     succeed_manually = Transition(
         [ActivityStateMachine.open, TimeBasedStateMachine.full, TimeBasedStateMachine.running],

--- a/bluebottle/time_based/tasks.py
+++ b/bluebottle/time_based/tasks.py
@@ -14,7 +14,7 @@ logger = logging.getLogger('bluebottle')
 
 
 @periodic_task(
-    run_every=(crontab(minute='*')),
+    run_every=(crontab(minute='*/15')),
     name="on_a_date_tasks",
     ignore_result=True
 )
@@ -26,7 +26,7 @@ def on_a_date_tasks():
 
 
 @periodic_task(
-    run_every=(crontab(minute='*')),
+    run_every=(crontab(minute='*/15')),
     name="with_a_deadline_tasks",
     ignore_result=True
 )
@@ -38,7 +38,7 @@ def with_a_deadline_tasks():
 
 
 @periodic_task(
-    run_every=(crontab(minute='*')),
+    run_every=(crontab(minute='*/15')),
     name="date_participant_tasks",
     ignore_result=True
 )
@@ -50,7 +50,7 @@ def date_participant_tasks():
 
 
 @periodic_task(
-    run_every=(crontab(minute='*')),
+    run_every=(crontab(minute='*/15')),
     name="period_participant_tasks",
     ignore_result=True
 )
@@ -62,7 +62,7 @@ def period_participant_tasks():
 
 
 @periodic_task(
-    run_every=(crontab(minute='*')),
+    run_every=(crontab(minute='*/15')),
     name="time_contribution_tasks",
     ignore_result=True
 )

--- a/bluebottle/time_based/tasks.py
+++ b/bluebottle/time_based/tasks.py
@@ -14,7 +14,7 @@ logger = logging.getLogger('bluebottle')
 
 
 @periodic_task(
-    run_every=(crontab(minute='*/15')),
+    run_every=(crontab(minute='*')),
     name="on_a_date_tasks",
     ignore_result=True
 )
@@ -26,7 +26,7 @@ def on_a_date_tasks():
 
 
 @periodic_task(
-    run_every=(crontab(minute='*/15')),
+    run_every=(crontab(minute='*')),
     name="with_a_deadline_tasks",
     ignore_result=True
 )
@@ -38,7 +38,7 @@ def with_a_deadline_tasks():
 
 
 @periodic_task(
-    run_every=(crontab(minute='*/15')),
+    run_every=(crontab(minute='*')),
     name="date_participant_tasks",
     ignore_result=True
 )
@@ -50,7 +50,7 @@ def date_participant_tasks():
 
 
 @periodic_task(
-    run_every=(crontab(minute='*/15')),
+    run_every=(crontab(minute='*')),
     name="period_participant_tasks",
     ignore_result=True
 )
@@ -62,7 +62,7 @@ def period_participant_tasks():
 
 
 @periodic_task(
-    run_every=(crontab(minute='*/15')),
+    run_every=(crontab(minute='*')),
     name="time_contribution_tasks",
     ignore_result=True
 )

--- a/bluebottle/time_based/templates/admin/transition_durations.html
+++ b/bluebottle/time_based/templates/admin/transition_durations.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+<h3>{{transition|capfirst}} contributed time</h3>
+
+<p>
+    {{transition|capfirst}} the contributed time by {{users.0.full_name}}  
+
+    {% if users|length > 1 %}
+        {% blocktrans with extra=users|length|add:"-1" %}
+            and {{ extra }} others
+        {% endblocktrans %}
+    {% endif %}
+</p>

--- a/bluebottle/time_based/tests/test_states.py
+++ b/bluebottle/time_based/tests/test_states.py
@@ -180,7 +180,7 @@ class PeriodActivityStatesTestCase(TimeBasedActivityStatesTestCase, BluebottleTe
 
         self.activity.refresh_from_db()
 
-        self.assertFalse(
+        self.assertTrue(
             PeriodStateMachine.succeed_manually in
             self.activity.states.possible_transitions()
         )

--- a/bluebottle/time_based/tests/test_triggers.py
+++ b/bluebottle/time_based/tests/test_triggers.py
@@ -608,6 +608,10 @@ class ParticipantTriggerTestCase():
             )
         )
         self.assertTrue(self.review_activity.followers.filter(user=participant.user).exists())
+        self.assertEqual(
+            participant.contributions.get().status,
+            'new'
+        )
 
     def test_initial_no_review(self):
         mail.outbox = []
@@ -625,6 +629,10 @@ class ParticipantTriggerTestCase():
             'A new participant has joined your activity "{}" 🎉'.format(self.activity.title)
         )
         self.assertTrue(self.activity.followers.filter(user=participant.user).exists())
+        self.assertEqual(
+            self.activity.accepted_participants.get().contributions.get().status,
+            'new'
+        )
 
     def test_no_review_fill(self):
         self.participant_factory.create_batch(
@@ -673,6 +681,11 @@ class ParticipantTriggerTestCase():
         mail.outbox = []
         self.participants[0].states.remove(save=True)
 
+        self.assertEqual(
+            self.participants[0].contributions.get().status,
+            'failed'
+        )
+
         self.activity.refresh_from_db()
         self.assertEqual(self.activity.status, 'open')
 
@@ -693,6 +706,11 @@ class ParticipantTriggerTestCase():
         mail.outbox = []
         self.participants[0].states.reject(save=True)
 
+        self.assertEqual(
+            self.participants[0].contributions.get().status,
+            'failed'
+        )
+
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(
             mail.outbox[0].subject,
@@ -709,6 +727,11 @@ class ParticipantTriggerTestCase():
 
         self.activity.refresh_from_db()
         self.assertEqual(self.activity.status, 'full')
+
+        self.assertEqual(
+            self.participants[0].contributions.get().status,
+            'new'
+        )
         self.assertTrue(self.activity.followers.filter(user=self.participants[0].user).exists())
 
     def test_withdraw(self):
@@ -723,6 +746,12 @@ class ParticipantTriggerTestCase():
 
         self.activity.refresh_from_db()
         self.assertEqual(self.activity.status, 'open')
+
+        self.assertEqual(
+            self.participants[0].contributions.get().status,
+            'failed'
+        )
+
         self.assertFalse(self.activity.followers.filter(user=self.participants[0].user).exists())
 
     def test_reapply(self):
@@ -733,6 +762,10 @@ class ParticipantTriggerTestCase():
         self.activity.refresh_from_db()
 
         self.assertEqual(self.activity.status, 'full')
+        self.assertEqual(
+            self.participants[0].contributions.get().status,
+            'new'
+        )
         self.assertTrue(self.activity.followers.filter(user=self.participants[0].user).exists())
 
 
@@ -746,58 +779,14 @@ class DateParticipantTriggerTestCase(ParticipantTriggerTestCase, BluebottleTestC
 
         self.assertEqual(self.activity.status, 'expired')
 
-        self.participant_factory.create(activity=self.activity)
+        participant = self.participant_factory.create(activity=self.activity)
 
         self.activity.refresh_from_db()
 
         self.assertEqual(self.activity.status, 'succeeded')
-
-    def test_initial_no_review(self):
-        super().test_initial_no_review()
-
         self.assertEqual(
-            self.activity.accepted_participants.get().contributions.get().status,
-            'new'
-        )
-
-    def test_initial_review(self):
-        super().test_initial_review()
-
-        self.assertEqual(
-            self.review_activity.participants.get().contributions.get().status,
-            'new'
-        )
-
-    def test_withdraw(self):
-        super().test_withdraw()
-
-        self.assertEqual(
-            self.participants[0].contributions.get().status,
-            'failed'
-        )
-
-    def test_reapply(self):
-        super().test_reapply()
-
-        self.assertEqual(
-            self.participants[0].contributions.get().status,
-            'new'
-        )
-
-    def test_reject(self):
-        super().test_reject()
-
-        self.assertEqual(
-            self.participants[0].contributions.get().status,
-            'failed'
-        )
-
-    def test_reaccept(self):
-        super().test_reaccept()
-
-        self.assertEqual(
-            self.participants[0].contributions.get().status,
-            'new'
+            participant.contributions.get().status,
+            'succeeded'
         )
 
 
@@ -811,8 +800,13 @@ class PeriodParticipantTriggerTestCase(ParticipantTriggerTestCase, BluebottleTes
 
         self.assertEqual(self.activity.status, 'expired')
 
-        self.participant_factory.create(activity=self.activity)
+        participant = self.participant_factory.create(activity=self.activity)
 
         self.activity.refresh_from_db()
 
         self.assertEqual(self.activity.status, 'succeeded')
+
+        self.assertEqual(
+            participant.contributions.get().status,
+            'succeeded'
+        )

--- a/bluebottle/time_based/triggers.py
+++ b/bluebottle/time_based/triggers.py
@@ -701,8 +701,8 @@ def duration_is_finished(effect):
     """
     return (
         (effect.instance.end is None or effect.instance.end < now()) and
-        effect.instance.contributor.status == 'accepted' and
-        effect.instance.contributor.activity.status == 'open'
+        effect.instance.contributor.status in ('accepted', 'new') and
+        effect.instance.contributor.activity.status in ('open', 'succeeded')
     )
 
 


### PR DESCRIPTION
Fix succeeding / failing and resetting of time contributions on various
transtions.
Fix creating and succeeding contributions on period participants.

If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
