### PR TITLE
Only show impact message in succeeded notification if impact is enabled.

### DIFF
--- a/bluebottle/time_based/messages.py
+++ b/bluebottle/time_based/messages.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from bluebottle.notifications.messages import TransitionMessage
 from django.utils.translation import ugettext_lazy as _
+from bluebottle.initiatives.models import InitiativePlatformSettings
 
 
 class DateChanged(TransitionMessage):
@@ -37,6 +38,12 @@ class ActivitySucceededNotification(TransitionMessage):
     context = {
         'title': 'title'
     }
+
+    def get_context(self, recipient):
+        context = super().get_context(recipient)
+        context['impact'] = InitiativePlatformSettings.load().enable_impact
+
+        return context
 
     def get_recipients(self):
         """activity owner"""

--- a/bluebottle/time_based/templates/mails/messages/activity_base.txt
+++ b/bluebottle/time_based/templates/mails/messages/activity_base.txt
@@ -5,9 +5,9 @@
 {% blocktrans with recipient_name=to.first_name context 'email' %}
 Hi {{ recipient_name }},
 {% endblocktrans %}
+{% block message %}{% endblock %}
 {% endblock %}
 
-{% block message %}{% endblock %}
 {% block action %}
    {% trans 'Go to your activity' context 'email' %}: {{ obj.get_absolute_url }}
 {% endblock %}`

--- a/bluebottle/time_based/templates/mails/messages/activity_cancelled.html
+++ b/bluebottle/time_based/templates/mails/messages/activity_cancelled.html
@@ -1,8 +1,8 @@
 {% extends "mails/messages/activity_base.html" %}
 {% load i18n %}
 
-{% block content %}{{block.super}}{% block message%}{% blocktrans with title=obj.title  context 'email' %}
+{% block message%}{% blocktrans with title=obj.title  context 'email' %}
 <p>Unfortunately your activity "{{ title }}" has been cancelled.</p>
 
 <p>If you have any questions, you can contact the platform manager by replying to this email.</p>
-{% endblocktrans %}{% endblock %}{% endblock %}
+{% endblocktrans %}{% endblock %}

--- a/bluebottle/time_based/templates/mails/messages/activity_cancelled.txt
+++ b/bluebottle/time_based/templates/mails/messages/activity_cancelled.txt
@@ -1,8 +1,8 @@
 {% extends "mails/messages/activity_base.txt" %}
 {% load i18n %}
 
-{% block content %}{{block.super}}{% block message%}{% blocktrans with title=obj.title  context 'email' %}
+{% block message%}{% blocktrans with title=obj.title  context 'email' %}
 Unfortunately your activity "{{ title }}" has been cancelled.
 
 If you have any questions, you can contact the platform manager by replying to this email.
-{% endblocktrans %}{% endblock %}{% endblock %}
+{% endblocktrans %}{% endblock %}

--- a/bluebottle/time_based/templates/mails/messages/activity_expired.html
+++ b/bluebottle/time_based/templates/mails/messages/activity_expired.html
@@ -1,10 +1,10 @@
 {% extends "mails/messages/activity_base.html" %}
 {% load i18n %}
 
-{% block content %}{{block.super}}{% block message%}{% blocktrans with title=obj.title  context 'email' %}
+{% block message%}{% blocktrans with title=obj.title  context 'email' %}
 <p>Unfortunately, nobody applied to your activity "{{ title }}" before the deadline to apply. That’s why we have cancelled your activity.</p>
 
 <p>Don’t worry, you can always create a new activity and try again.</p> 
 
 <p>Need some tips to make your activity stand out? Reach out to the platform manager by replying to this email.</p>
-{% endblocktrans %}{% endblock %}{% endblock %}
+{% endblocktrans %}{% endblock %}

--- a/bluebottle/time_based/templates/mails/messages/activity_expired.txt
+++ b/bluebottle/time_based/templates/mails/messages/activity_expired.txt
@@ -1,10 +1,10 @@
 {% extends "mails/messages/activity_base.txt" %}
 {% load i18n %}
 
-{% block content %}{{block.super}}{% block message%}{% blocktrans with title=obj.title  context 'email' %}
+{% block message%}{% blocktrans with title=obj.title  context 'email' %}
 Unfortunately, nobody applied to your activity "{{ title }}" before the deadline to apply. That’s why we have cancelled your activity.
 
 Don’t worry, you can always create a new activity and try again. 
 
 Need some tips to make your activity stand out? Reach out to the platform manager by replying to this email.
-{% endblocktrans %}{% endblock %}{% endblock %}
+{% endblocktrans %}{% endblock %}

--- a/bluebottle/time_based/templates/mails/messages/activity_rejected.html
+++ b/bluebottle/time_based/templates/mails/messages/activity_rejected.html
@@ -1,8 +1,8 @@
 {% extends "mails/messages/activity_base.html" %}
 {% load i18n %}
 
-{% block content %}{{block.super}}{% block message%}{% blocktrans with title=obj.title  context 'email' %}
+{% block message%}{% blocktrans with title=obj.title  context 'email' %}
 <p>Unfortunately your activity "{{ title }}" has been rejected.</p>
 
 <p>If you have any questions, you can contact the platform manager by replying to this email.</p>
-{% endblocktrans %}{% endblock %}{% endblock %}
+{% endblocktrans %}{% endblock %}

--- a/bluebottle/time_based/templates/mails/messages/activity_rejected.txt
+++ b/bluebottle/time_based/templates/mails/messages/activity_rejected.txt
@@ -1,8 +1,8 @@
 {% extends "mails/messages/activity_base.txt" %}
 {% load i18n %}
 
-{% block content %}{{block.super}}{% block message%}{% blocktrans with title=obj.title  context 'email' %}
+{% block message%}{% blocktrans with title=obj.title  context 'email' %}
 Unfortunately your activity "{{ title }}" has been rejected.
 
 If you have any questions, you can contact the platform manager by replying to this email.
-{% endblocktrans %}{% endblock %}{% endblock %}
+{% endblocktrans %}{% endblock %}

--- a/bluebottle/time_based/templates/mails/messages/activity_succeeded.html
+++ b/bluebottle/time_based/templates/mails/messages/activity_succeeded.html
@@ -1,10 +1,17 @@
 {% extends "mails/messages/activity_base.html" %}
 {% load i18n %}
 
-{% block content %}{{block.super}}{% block message%}{% blocktrans with title=obj.title  context 'email' %}
+{% block message%}{% blocktrans with title=obj.title  context 'email' %}
 <p>You did it! Your activity "{{ title }}" has succeeded, that calls for a celebration!</p>
+{% endblocktrans %}
 
-<p>Head over to your activity page and enter the impact your activity made, so that everybody can see how effective your activity was.</p>
+{% if impact %}
+    {% blocktrans %}
+        <p>Head over to your activity page and enter the impact your activity made, so that everybody can see how effective your activity was.</p>
+    {% endblocktrans %}
+{% endif %}
 
-<p>And don’t forget to thank your awesome participants for their support.</p>
-{% endblocktrans %}{% endblock %}{% endblock %}
+{% blocktrans %}
+    <p>And don’t forget to thank your awesome participants for their support.</p>
+{% endblocktrans %}
+{% endblock %}

--- a/bluebottle/time_based/templates/mails/messages/activity_succeeded.txt
+++ b/bluebottle/time_based/templates/mails/messages/activity_succeeded.txt
@@ -1,10 +1,11 @@
 {% extends "mails/messages/activity_base.txt" %}
 {% load i18n %}
 
-{% block content %}{{block.super}}{% block message%}{% blocktrans with title=obj.title  context 'email' %}
+{% block message%}{% blocktrans with title=obj.title  context 'email' %}
 You did it! Your activity "{{ title }}" has succeeded, that calls for a celebration!
+{{% endblocktrans %}
 
-Head over to your activity page and enter the impact your activity made, so that everybody can see how effective your activity was.
+{% if impact %}{% blocktrans %}Head over to your activity page and enter the impact your activity made, so that everybody can see how effective your activity was.{% endblocktrans %}{% endif %}
 
-And don’t forget to thank your awesome participants for their support.
-{% endblocktrans %}{% endblock %}{% endblock %}
+{% blocktrans %}And don’t forget to thank your awesome participants for their support.{% endblocktrans %}
+{% endblock %}

--- a/bluebottle/time_based/templates/mails/messages/activity_succeeded_manually.html
+++ b/bluebottle/time_based/templates/mails/messages/activity_succeeded_manually.html
@@ -1,8 +1,8 @@
 {% extends "mails/messages/activity_base.html" %}
 {% load i18n %}
 
-{% block content %}{{block.super}}{% block message%}{% blocktrans with title=obj.title  context 'email' %}
+{% block message%}{% blocktrans with title=obj.title  context 'email' %}
 <p>You did it! The activity "{{ title }}" has succeeded, that calls for a celebration!</p>
 
 <p>Share your experience on the activity page.</p>
-{% endblocktrans %}{% endblock %}{% endblock %}
+{% endblocktrans %}{% endblock %}

--- a/bluebottle/time_based/templates/mails/messages/activity_succeeded_manually.txt
+++ b/bluebottle/time_based/templates/mails/messages/activity_succeeded_manually.txt
@@ -1,8 +1,8 @@
 {% extends "mails/messages/activity_base.txt" %}
 {% load i18n %}
 
-{% block content %}{{block.super}}{% block message%}{% blocktrans with title=obj.title  context 'email' %}
+{% block message%}{% blocktrans with title=obj.title  context 'email' %}
 You did it! The activity "{{ title }}" has succeeded, that calls for a celebration!
 
 Share your experience on the activity page.
-{% endblocktrans %}{% endblock %}{% endblock %}
+{% endblocktrans %}{% endblock %}

--- a/bluebottle/time_based/templates/mails/messages/date_changed.html
+++ b/bluebottle/time_based/templates/mails/messages/date_changed.html
@@ -2,12 +2,10 @@
 {% load i18n %}
 {% load local_time %}
 
-{% block content %}
-{{block.super}}
 {% block message%}{% blocktrans with title=obj.title date=obj.start|local_date:obj.local_timezone start=obj.start|local_time:obj.local_timezone end=obj.end|local_time:obj.local_timezone tz=obj.start|local_timezone:obj.local_timezone context 'email' %}
 <p>The date and/or time of the activity "{{ title }}" has changed.</p>
 
 <p>The new date is {{ date }} from {{ start }} to {{ end }} ({{tz}}).</p>
 
 <p>If you are unable to participate, please withdraw via the activity page so that others can take your place.</p>
-{% endblocktrans %}{% endblock %}{% endblock %}
+{% endblocktrans %}{% endblock %}

--- a/bluebottle/time_based/templates/mails/messages/date_changed.txt
+++ b/bluebottle/time_based/templates/mails/messages/date_changed.txt
@@ -2,12 +2,10 @@
 {% load i18n %}
 {% load local_time %}
 
-{% block content %}
-{{block.super}}
 {% block message%}{% blocktrans with title=obj.title date=obj.start|local_date:obj.local_timezone start=obj.start|local_time:obj.local_timezone end=obj.end|local_time:obj.local_timezone tz=obj.start|local_timezone:obj.local_timezone context 'email' %}
 The date and/or time of the activity "{{ title }}" has changed.
 
 The new date is {{ date }} from {{ start }} to {{ end }} ({{tz}}).
 
 If you are unable to participate, please withdraw via the activity page so that others can take your place.
-{% endblocktrans %}{% endblock %}{% endblock %}
+{% endblocktrans %}{% endblock %}

--- a/bluebottle/time_based/templates/mails/messages/deadline_changed.html
+++ b/bluebottle/time_based/templates/mails/messages/deadline_changed.html
@@ -2,12 +2,10 @@
 {% load i18n %}
 {% load local_time %}
 
-{% block content %}
-{{block.super}}
 {% block message%}{% blocktrans with title=obj.title date=obj.start|local_date:obj.local_timezone start=obj.start|local_time:obj.local_timezone end=obj.end|local_time:obj.local_timezone tz=obj.start|local_timezone:obj.local_timezone context 'email' %}
 <p>The date and/or time of the activity "{{ title }}" has changed.</p>
 
 <p>The new date is {{ date }} from {{ start }} to {{ end }} ({{tz}}).</p>
 
 <p>If you are unable to participate, please withdraw via the activity page so that others can take your place.</p>
-{% endblocktrans %}{% endblock %}{% endblock %}
+{% endblocktrans %}{% endblock %}

--- a/bluebottle/time_based/templates/mails/messages/deadline_changed.txt
+++ b/bluebottle/time_based/templates/mails/messages/deadline_changed.txt
@@ -2,12 +2,10 @@
 {% load i18n %}
 {% load local_time %}
 
-{% block content %}
-{{block.super}}
 {% block message%}{% blocktrans with title=obj.title date=obj.start|local_date:obj.local_timezone start=obj.start|local_time:obj.local_timezone end=obj.end|local_time:obj.local_timezone tz=obj.start|local_timezone:obj.local_timezone context 'email' %}
 The date and/or time of the activity "{{ title }}" has changed.
 
 The new date is {{ date }} from {{ start }} to {{ end }} ({{tz}}).
 
 If you are unable to participate, please withdraw via the activity page so that others can take your place.
-{% endblocktrans %}{% endblock %}{% endblock %}
+{% endblocktrans %}{% endblock %}

--- a/bluebottle/time_based/templates/mails/messages/participant_added.html
+++ b/bluebottle/time_based/templates/mails/messages/participant_added.html
@@ -1,10 +1,10 @@
 {% extends "mails/messages/participant_base.html" %}
 {% load i18n %}
 
-{% block content %}{{block.super}}{% block message%}{% blocktrans with title=obj.activity.title  context 'email' %}
+{% block message%}{% blocktrans with title=obj.activity.title  context 'email' %}
 <p>You have been added to the activity "{{ title }}" as a participant.</p>
 
 <p>Head over to the activity page for more information.</p>
 
 <p>If you are unable to participate, please withdraw via the activity page so that others can take your place.</p>
-{% endblocktrans %}{% endblock %}{% endblock %}
+{% endblocktrans %}{% endblock %}

--- a/bluebottle/time_based/templates/mails/messages/participant_added.txt
+++ b/bluebottle/time_based/templates/mails/messages/participant_added.txt
@@ -1,10 +1,10 @@
 {% extends "mails/messages/participant_base.txt" %}
 {% load i18n %}
 
-{% block content %}{{block.super}}{% block message%}{% blocktrans with title=obj.activity.title  context 'email' %}
+{% block message%}{% blocktrans with title=obj.activity.title  context 'email' %}
 You have been added to the activity "{{ title }}" as a participant.
 
 Head over to the activity page for more information.
 
 If you are unable to participate, please withdraw via the activity page so that others can take your place.
-{% endblocktrans %}{% endblock %}{% endblock %}
+{% endblocktrans %}{% endblock %}

--- a/bluebottle/time_based/templates/mails/messages/participant_created.html
+++ b/bluebottle/time_based/templates/mails/messages/participant_created.html
@@ -1,11 +1,11 @@
 {% extends "mails/messages/participant_base.html" %}
 {% load i18n %}
 
-{% block content %}{{block.super}}{% block message%}{% blocktrans with title=obj.activity.title applicant=obj.activity.user.full_name context 'email' %}
+{% block message%}{% blocktrans with title=obj.activity.title applicant=obj.activity.user.full_name context 'email' %}
 <p>{{ applicant }} applied to your activity "{{ title}}".<p>
 
 <p>Review the application and decide if this person is the right fit.</p>
-{% endblocktrans %}{% endblock %}{% endblock %}
+{% endblocktrans %}{% endblock %}
 {% block action %}
     <a href="{{ obj.activity.get_absolute_url }}"
        class="action-email">{% trans 'Review the application' context 'email' %}</a>

--- a/bluebottle/time_based/templates/mails/messages/participant_created.txt
+++ b/bluebottle/time_based/templates/mails/messages/participant_created.txt
@@ -1,11 +1,11 @@
 {% extends "mails/messages/participant_base.txt" %}
 {% load i18n %}
 
-{% block content %}{{block.super}}{% block message%}{% blocktrans with title=obj.activity.title applicant=obj.user.full_name context 'email' %}
+{% block message%}{% blocktrans with title=obj.activity.title applicant=obj.user.full_name context 'email' %}
 {{ applicant }} applied to your activity "{{ title}}".
 
 Review the application and decide if this person is the right fit.
-{% endblocktrans %}{% endblock %}{% endblock %}
+{% endblocktrans %}{% endblock %}
 {% block action %}
 {% trans 'Review the application' context 'email' %}: {{ obj.activity.get_absolute_url }}
 {% endblock %}`


### PR DESCRIPTION
Fix mail templates.

If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
