### PR TITLE
Make is_online not required anymore in the serializer

### DIFF
--- a/bluebottle/time_based/serializers.py
+++ b/bluebottle/time_based/serializers.py
@@ -66,6 +66,7 @@ class TimeBasedBaseSerializer(BaseActivitySerializer):
 
 
 class ActivitySlotSerializer(ModelSerializer):
+    is_online = serializers.NullBooleanField()
     permissions = ResourcePermissionField('date-slot-detail', view_args=('pk',))
     transitions = AvailableTransitionsField(source='states')
 


### PR DESCRIPTION
If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
