### PR TITLE
No longer unset the start date when reopening. Let staff user reapply…

### DIFF
--- a/bluebottle/time_based/effects.py
+++ b/bluebottle/time_based/effects.py
@@ -108,14 +108,6 @@ class SetEndDateEffect(Effect):
         self.instance.deadline = date.today()
 
 
-class ClearStartEffect(Effect):
-    title = _('Clear the start date of the activity')
-    template = 'admin/clear_start.html'
-
-    def pre_save(self, **kwargs):
-        self.instance.start = None
-
-
 class ClearDeadlineEffect(Effect):
     title = _('Clear the deadline of the activity')
     template = 'admin/clear_deadline.html'

--- a/bluebottle/time_based/states.py
+++ b/bluebottle/time_based/states.py
@@ -312,7 +312,7 @@ class ParticipantStateMachine(ContributorStateMachine):
 
     def is_user(self, user):
         """is participant"""
-        return self.instance.user == user
+        return self.instance.user == user or user.is_staff
 
     def can_accept_participant(self, user):
         """can accept participant"""
@@ -406,7 +406,7 @@ class ParticipantStateMachine(ContributorStateMachine):
         description=_("User re-applies for the task after previously withdrawing."),
         automatic=False,
         conditions=[activity_is_open],
-        permission=ContributorStateMachine.is_user,
+        permission=is_user,
     )
 
 

--- a/bluebottle/time_based/triggers.py
+++ b/bluebottle/time_based/triggers.py
@@ -16,7 +16,7 @@ from bluebottle.fsm.triggers import (
 from bluebottle.notifications.effects import NotificationEffect
 from bluebottle.time_based.effects import (
     CreatePeriodTimeContributionEffect, SetEndDateEffect,
-    ClearStartEffect, ClearDeadlineEffect,
+    ClearDeadlineEffect,
     RescheduleDurationsEffect,
     ActiveTimeContributionsTransitionEffect, CreateSlotParticipantsForParticipantsEffect,
     CreateSlotParticipantsForSlotsEffect, CreateSlotTimeContributionEffect, UnlockUnfilledSlotsEffect,
@@ -266,7 +266,6 @@ class DateActivityTriggers(TimeBasedTriggers):
         TransitionTrigger(
             DateStateMachine.reopen_manually,
             effects=[
-                ClearStartEffect,
                 ActiveTimeContributionsTransitionEffect(TimeContributionStateMachine.reset)
             ]
         ),


### PR DESCRIPTION
… other users

If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
