### PR TITLE
Mark is_online as required for activity slots

### DIFF
--- a/bluebottle/time_based/models.py
+++ b/bluebottle/time_based/models.py
@@ -315,7 +315,8 @@ class DateActivitySlot(ActivitySlot):
     def required_fields(self):
         fields = [
             'start',
-            'duration'
+            'duration',
+            'is_online',
         ]
         if not self.is_online:
             fields.append('location')


### PR DESCRIPTION
If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
