### PR TITLE
Reschedule time contributions when change the start and deadline of

### DIFF
--- a/bluebottle/time_based/tests/test_triggers.py
+++ b/bluebottle/time_based/tests/test_triggers.py
@@ -2,7 +2,7 @@ from datetime import timedelta, date
 
 from django.core import mail
 from django.template import defaultfilters
-from django.utils.timezone import now
+from django.utils.timezone import now, get_current_timezone
 from tenant_extras.utils import TenantLanguage
 
 from bluebottle.activities.models import Organizer
@@ -501,6 +501,46 @@ class PeriodActivityTriggerTestCase(TimeBasedActivityTriggerTestCase, Bluebottle
                 'The activity "{}" has succeeded 🎉'.format(self.activity.title)
             )
 
+    def test_reschedule_contributions(self):
+        self.participant_factory.create_batch(5, activity=self.activity)
+
+        self.assertEqual(len(self.activity.durations), 5)
+
+        tz = get_current_timezone()
+
+        for duration in self.activity.durations:
+            self.assertEqual(duration.start.astimezone(tz).date(), self.activity.start)
+            self.assertEqual(duration.end.astimezone(tz).date(), self.activity.deadline)
+
+        self.activity.start = self.activity.start + timedelta(days=1)
+        self.activity.save()
+
+        for duration in self.activity.durations:
+            self.assertEqual(duration.start.astimezone(tz).date(), self.activity.start)
+            self.assertEqual(duration.end.astimezone(tz).date(), self.activity.deadline)
+
+        self.activity.deadline = self.activity.deadline + timedelta(days=1)
+        self.activity.save()
+
+        for duration in self.activity.durations:
+            self.assertEqual(duration.start.astimezone(tz).date(), self.activity.start)
+            self.assertEqual(duration.end.astimezone(tz).date(), self.activity.deadline)
+
+        current_start = self.activity.start
+        self.activity.start = None
+        self.activity.save()
+
+        for duration in self.activity.durations:
+            self.assertEqual(duration.start.astimezone(tz).date(), current_start)
+            self.assertEqual(duration.end.astimezone(tz).date(), self.activity.deadline)
+
+        self.activity.deadline = None
+        self.activity.save()
+
+        for duration in self.activity.durations:
+            self.assertEqual(duration.start.astimezone(tz).date(), current_start)
+            self.assertEqual(duration.end, None)
+
 
 class DateActivitySlotTriggerTestCase(BluebottleTestCase):
     def setUp(self):
@@ -665,6 +705,30 @@ class DateActivitySlotTriggerTestCase(BluebottleTestCase):
                 defaultfilters.time(self.slot2.end),
             )
         self.assertTrue(expected in mail.outbox[0].body)
+
+    def test_reschedule_contributions(self):
+        DateParticipantFactory.create_batch(5, activity=self.activity)
+
+        for duration in self.slot.durations:
+            self.assertEqual(duration.start, self.slot.start)
+            self.assertEqual(duration.end, self.slot.start + self.slot.duration)
+            self.assertEqual(duration.value, self.slot.duration)
+
+        self.slot.start = self.slot.start + timedelta(days=1)
+        self.slot.save()
+
+        for duration in self.slot.durations:
+            self.assertEqual(duration.start, self.slot.start)
+            self.assertEqual(duration.end, self.slot.start + self.slot.duration)
+            self.assertEqual(duration.value, self.slot.duration)
+
+        self.slot.duration = self.slot.duration + timedelta(hours=1)
+        self.slot.save()
+
+        for duration in self.slot.durations:
+            self.assertEqual(duration.start, self.slot.start)
+            self.assertEqual(duration.end, self.slot.start + self.slot.duration)
+            self.assertEqual(duration.value, self.slot.duration)
 
 
 class ParticipantTriggerTestCase():

--- a/bluebottle/time_based/triggers.py
+++ b/bluebottle/time_based/triggers.py
@@ -17,11 +17,12 @@ from bluebottle.notifications.effects import NotificationEffect
 from bluebottle.time_based.effects import (
     CreatePeriodTimeContributionEffect, SetEndDateEffect,
     ClearDeadlineEffect,
-    RescheduleDurationsEffect,
+    RescheduleSlotDurationsEffect,
     ActiveTimeContributionsTransitionEffect, CreateSlotParticipantsForParticipantsEffect,
     CreateSlotParticipantsForSlotsEffect, CreateSlotTimeContributionEffect, UnlockUnfilledSlotsEffect,
     LockFilledSlotsEffect, CreatePreparationTimeContributionEffect,
-    ResetSlotSelectionEffect, UnsetCapacityEffect
+    ResetSlotSelectionEffect, UnsetCapacityEffect,
+    RescheduleOverallPeriodActivityDurationsEffect
 )
 from bluebottle.time_based.messages import (
     DeadlineChangedNotification,
@@ -583,7 +584,14 @@ class DateActivitySlotTriggers(ActivitySlotTriggers):
                         is_not_finished
                     ]
                 ),
-                RescheduleDurationsEffect
+                RescheduleSlotDurationsEffect
+            ]
+        ),
+
+        ModelChangedTrigger(
+            'duration',
+            effects=[
+                RescheduleSlotDurationsEffect
             ]
         ),
 
@@ -604,6 +612,13 @@ class PeriodActivityTriggers(TimeBasedTriggers):
                     is_not_started,
                     registration_deadline_is_not_passed
                 ]),
+            ]
+        ),
+
+        ModelChangedTrigger(
+            ['start', 'deadline'],
+            effects=[
+                RescheduleOverallPeriodActivityDurationsEffect
             ]
         ),
 


### PR DESCRIPTION
period contributions

Fix and test rescheduling time contributions when slot start or duration
changes.

If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
