### PR TITLE
Do not error when an image is related to multiple objects.

### DIFF
--- a/bluebottle/files/serializers.py
+++ b/bluebottle/files/serializers.py
@@ -98,7 +98,7 @@ class DocumentSerializer(ModelSerializer):
 
     def get_link(self, obj):
         if self.relationship and self.content_view_name:
-            parent_id = getattr(obj, self.relationship).get().pk
+            parent_id = getattr(obj, self.relationship).first().pk
             return reverse(self.content_view_name, args=(parent_id, 'main'))
 
     def get_filename(self, instance):
@@ -116,7 +116,7 @@ class DocumentSerializer(ModelSerializer):
 class PrivateDocumentSerializer(DocumentSerializer):
 
     def get_link(self, obj):
-        parent_id = getattr(obj, self.relationship).get().pk
+        parent_id = getattr(obj, self.relationship).first().pk
         return reverse_signed(self.content_view_name, args=(parent_id, ))
 
     class Meta(object):


### PR DESCRIPTION
I have no idea how that could happen, but it does and breaks.
This has the weird side-effect that the link of the image will point to
the id of the first related object instead of the current. But fixing it
properly is not really possible now.

If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
