### PR TITLE
Add status field to deed participant admin. Succeed when re-accepting…

### DIFF
--- a/bluebottle/deeds/admin.py
+++ b/bluebottle/deeds/admin.py
@@ -24,7 +24,7 @@ class DeedAdminForm(StateMachineModelForm):
 class DeedParticipantAdmin(ContributorChildAdmin):
     readonly_fields = ['created']
     raw_id_fields = ['user', 'activity']
-    fields = ['activity', 'user', 'states'] + readonly_fields
+    fields = ['activity', 'user', 'status', 'states'] + readonly_fields
     list_display = ['__str__', 'activity_link', 'status']
 
 

--- a/bluebottle/deeds/states.py
+++ b/bluebottle/deeds/states.py
@@ -27,7 +27,7 @@ class DeedStateMachine(ActivityStateMachine):
     )
 
     succeed = Transition(
-        [ActivityStateMachine.open, running],
+        [ActivityStateMachine.open, running, ActivityStateMachine.expired],
         ActivityStateMachine.succeeded,
         name=_('Succeed'),
         automatic=True,
@@ -192,7 +192,6 @@ class DeedParticipantStateMachine(ContributorStateMachine):
         description=_("Remove participant from the activity."),
         automatic=False,
         permission=is_owner,
-        hide_from_admin=True,
     )
 
     accept = Transition(

--- a/bluebottle/deeds/tests/test_triggers.py
+++ b/bluebottle/deeds/tests/test_triggers.py
@@ -433,6 +433,10 @@ class DeedParticipantTriggersTestCase(TriggerTestCase):
                 DeedParticipantStateMachine.succeed
             )
 
+            self.assertTransitionEffect(
+                DeedStateMachine.succeed, self.model.activity
+            )
+
     def test_succeed_accept(self):
         self.defaults['status'] = 'rejected'
         self.create()
@@ -445,5 +449,5 @@ class DeedParticipantTriggersTestCase(TriggerTestCase):
         self.model.states.accept()
 
         with self.execute():
-            self.assertNoTransitionEffect(DeedStateMachine.succeed, self.model.activity)
+            self.assertTransitionEffect(DeedStateMachine.succeed, self.model.activity)
             self.assertNotificationEffect(ParticipantFinishedNotification)

--- a/bluebottle/deeds/triggers.py
+++ b/bluebottle/deeds/triggers.py
@@ -226,6 +226,18 @@ class DeedParticipantTriggers(ContributorTriggers):
         ),
 
         TransitionTrigger(
+            DeedParticipantStateMachine.succeed,
+            effects=[
+                RelatedTransitionEffect(
+                    'activity',
+                    DeedStateMachine.succeed,
+                    conditions=[activity_is_finished]
+                ),
+                RelatedTransitionEffect('contributions', EffortContributionStateMachine.succeed),
+            ]
+        ),
+
+        TransitionTrigger(
             DeedParticipantStateMachine.accept,
             effects=[
                 TransitionEffect(


### PR DESCRIPTION
… participants in expired activity

If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
