### PR TITLE
Fix timezone displays in date activity mails

### DIFF
--- a/bluebottle/time_based/messages.py
+++ b/bluebottle/time_based/messages.py
@@ -1,21 +1,33 @@
 # -*- coding: utf-8 -*-
+from pytz import timezone
+
 from django.template import defaultfilters
 from django.utils.translation import pgettext_lazy as pgettext
+from django.utils.timezone import get_current_timezone
 
 from bluebottle.clients.utils import tenant_url
 from bluebottle.notifications.messages import TransitionMessage
 
 
 def get_slot_info(slot):
+    if slot.location and not slot.is_online:
+        tz = timezone(slot.location.timezone)
+    else:
+        tz = get_current_timezone()
+
+    start = slot.start.astimezone(tz)
+    end = slot.end.astimezone(tz)
+
     return {
         'title': slot.title or str(slot),
         'is_online': slot.is_online,
         'online_meeting_url': slot.online_meeting_url,
         'location': slot.location.formatted_address if slot.location else '',
         'location_hint': slot.location_hint,
-        'start_date': defaultfilters.date(slot.start),
-        'start_time': defaultfilters.time(slot.start),
-        'end_time': defaultfilters.time(slot.end),
+        'start_date': defaultfilters.date(start),
+        'start_time': defaultfilters.time(start),
+        'end_time': defaultfilters.time(end),
+        'timezone': start.strftime('%Z')
     }
 
 

--- a/bluebottle/time_based/templates/mails/messages/changed_single_date.html
+++ b/bluebottle/time_based/templates/mails/messages/changed_single_date.html
@@ -3,7 +3,7 @@
 {% block message %}
 <p>
 {% blocktrans context 'email' %}
-The activity "{{ title }}" takes place on {{ start_date }} {{ start_time }} - {{ end_time }}.
+The activity "{{ title }}" takes place on {{ start_date }} {{ start_time }} - {{ end_time }} ({{timezone}}).
 {% endblocktrans %}
 </p>
 <p>

--- a/bluebottle/time_based/templates/mails/messages/changed_single_date.txt
+++ b/bluebottle/time_based/templates/mails/messages/changed_single_date.txt
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% block message %}
 {% blocktrans context 'email' %}
-The activity "{{ title }}" takes place on {{ start_date }} {{ start_time }} - {{ end_time }}.
+The activity "{{ title }}" takes place on {{ start_date }} {{ start_time }} - {{ end_time }} ({{timezone}}).
 {% endblocktrans %}
 
 {% if is_online %}

--- a/bluebottle/time_based/templates/mails/messages/partial/slots.html
+++ b/bluebottle/time_based/templates/mails/messages/partial/slots.html
@@ -8,7 +8,7 @@
         {% trans "Changed" %}
     {% endif %}
     <br/>
-    {{ slot.start_date }} {{ slot.start_time }} - {{ slot.end_time }}
+    {{ slot.start_date }} {{ slot.start_time }} - {{ slot.end_time }} ({{timezone}})
     <br/>
     {% if slot.is_online %}
         {% if slot.online_meeting_url %}

--- a/bluebottle/time_based/templates/mails/messages/partial/slots.txt
+++ b/bluebottle/time_based/templates/mails/messages/partial/slots.txt
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% for slot in slots %}
 {{ slot.title }}
-{{ slot.start_date }} {{ slot.start_time }} - {{ slot.end_time }}
+{{ slot.start_date }} {{ slot.start_time }} - {{ slot.end_time }} ({{slot.timezone}})
 {% if slot.is_online %}{% if slot.online_meeting_url %}{{ slot.online_meeting_url }}{% else %}{% trans "Anywhere/Online" %}{% endif %}{% else %}{{ slot.location }}{% if slot.location_hint %} - {{ slot.location_hint }}{% endif %}{% endif %}
 {% if slot.changed %}{% trans "(Changed)" %}
 {% endif %}{% endfor %}

--- a/bluebottle/time_based/templates/mails/messages/reminder_single_date.html
+++ b/bluebottle/time_based/templates/mails/messages/reminder_single_date.html
@@ -3,7 +3,7 @@
 {% block message %}
 <p>
 {% blocktrans context 'email' %}
-The activity "{{ title }}" takes place on {{ start_date }} {{ start_time }} - {{ end_time }}. That is just a few days away!
+The activity "{{ title }}" takes place on {{ start_date }} {{ start_time }} - {{ end_time }} ({{timezone}}). That is just a few days away!
 {% endblocktrans %}
 </p>
 

--- a/bluebottle/time_based/templates/mails/messages/reminder_single_date.txt
+++ b/bluebottle/time_based/templates/mails/messages/reminder_single_date.txt
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% block message %}
 {% blocktrans context 'email' %}
-The activity "{{ title }}" takes place on {{ start_date }} {{ start_time }} - {{ end_time }}. That is just a few days away!
+The activity "{{ title }}" takes place on {{ start_date }} {{ start_time }} - {{ end_time }} ({{timezone}}). That is just a few days away!
 {% endblocktrans %}
 
 {% blocktrans context 'email' %}

--- a/bluebottle/time_based/tests/test_triggers.py
+++ b/bluebottle/time_based/tests/test_triggers.py
@@ -668,12 +668,14 @@ class DateActivitySlotTriggerTestCase(BluebottleTestCase):
             'The details of activity "{}" have changed'.format(self.activity.title)
         )
         with TenantLanguage('en'):
-            expected = 'The activity "{}" takes place on {} {} - {}'.format(
+            expected = 'The activity "{}" takes place on {} {} - {} ({})'.format(
                 self.activity.title,
                 defaultfilters.date(self.slot.start),
-                defaultfilters.time(self.slot.start),
-                defaultfilters.time(self.slot.end),
+                defaultfilters.time(self.slot.start.astimezone(get_current_timezone())),
+                defaultfilters.time(self.slot.end.astimezone(get_current_timezone())),
+                self.slot.start.astimezone(get_current_timezone()).strftime('%Z'),
             )
+
         self.assertTrue(expected in mail.outbox[0].body)
 
     def test_changed_multiple_dates(self):
@@ -692,17 +694,19 @@ class DateActivitySlotTriggerTestCase(BluebottleTestCase):
             'The details of activity "{}" have changed'.format(self.activity.title)
         )
         with TenantLanguage('en'):
-            expected = '{} {} - {}'.format(
+            expected = '{} {} - {} ({})'.format(
                 defaultfilters.date(self.slot.start),
-                defaultfilters.time(self.slot.start),
-                defaultfilters.time(self.slot.end),
+                defaultfilters.time(self.slot.start.astimezone(get_current_timezone())),
+                defaultfilters.time(self.slot.end.astimezone(get_current_timezone())),
+                self.slot.start.astimezone(get_current_timezone()).strftime('%Z'),
             )
         self.assertTrue(expected in mail.outbox[0].body)
         with TenantLanguage('en'):
-            expected = '{} {} - {}'.format(
+            expected = '{} {} - {} ({})'.format(
                 defaultfilters.date(self.slot2.start),
-                defaultfilters.time(self.slot2.start),
-                defaultfilters.time(self.slot2.end),
+                defaultfilters.time(self.slot2.start.astimezone(get_current_timezone())),
+                defaultfilters.time(self.slot2.end.astimezone(get_current_timezone())),
+                self.slot2.start.astimezone(get_current_timezone()).strftime('%Z'),
             )
         self.assertTrue(expected in mail.outbox[0].body)
 


### PR DESCRIPTION
If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
