### PR TITLE
Return correct error when creating user with invalid email adres

### DIFF
--- a/bluebottle/members/serializers.py
+++ b/bluebottle/members/serializers.py
@@ -444,7 +444,7 @@ class UserCreateSerializer(serializers.ModelSerializer):
     def errors(self):
         errors = super(UserCreateSerializer, self).errors
 
-        if 'email' in errors and 'email' in self.data:
+        if 'email' in errors and 'email' in self.data and errors['email'][0].code == 'unique':
             user = self.Meta.model.objects.get(email=self.data['email'])
 
             conflict = {

--- a/bluebottle/members/tests/test_api.py
+++ b/bluebottle/members/tests/test_api.py
@@ -195,6 +195,20 @@ class CreateUserTestCase(BluebottleTestCase):
         self.assertEqual(member.is_active, True)
         self.assertTrue(member.check_password(password))
 
+    def test_create_invalid(self):
+        email = 'test@example%2ecom'
+        password = 'test@example.com'
+
+        response = self.client.post(
+            reverse('user-user-create'),
+            {'email': email, 'password': password, 'password_confirmation': password}
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json()['email'][0],
+            'Enter a valid email address.'
+        )
+
     def test_create_twice(self):
         email = 'test@example.com'
         password = 'test@example.com'


### PR DESCRIPTION
If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
