### PR TITLE
Add possibility to override jwt token expiration in tenant settings.

### DIFF
--- a/bluebottle/auth/middleware.py
+++ b/bluebottle/auth/middleware.py
@@ -19,6 +19,7 @@ from rest_framework import exceptions
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 from rest_framework_jwt.settings import api_settings
 
+from bluebottle.clients import properties
 from bluebottle.utils.utils import get_client_ip
 
 LAST_SEEN_DELTA = 10  # in minutes
@@ -91,7 +92,7 @@ class SlidingJwtTokenMiddleware(object):
             # hasn't been renewed in JWT_TOKEN_RENEWAL_DELTA
             exp = payload.get('exp')
             created_timestamp = exp - int(
-                api_settings.JWT_EXPIRATION_DELTA.total_seconds())
+                properties.JWT_EXPIRATION_DELTA.total_seconds())
             renewal_timestamp = created_timestamp + int(
                 settings.JWT_TOKEN_RENEWAL_DELTA.total_seconds())
             now_timestamp = timegm(datetime.utcnow().utctimetuple())
@@ -106,10 +107,11 @@ class SlidingJwtTokenMiddleware(object):
 
             # Get and check orig_iat
             orig_iat = payload.get('orig_iat')
+
             if orig_iat:
                 # verify expiration
                 expiration_timestamp = orig_iat + int(
-                    api_settings.JWT_TOKEN_RENEWAL_LIMIT.total_seconds())
+                    settings.JWT_TOKEN_RENEWAL_LIMIT.total_seconds())
                 if now_timestamp > expiration_timestamp:
                     # Token has passed renew time limit - just return existing
                     # response. We need to test this process because it is

--- a/bluebottle/members/tests/test_api.py
+++ b/bluebottle/members/tests/test_api.py
@@ -1,5 +1,8 @@
 from builtins import range
 import time
+from datetime import datetime, timedelta
+from calendar import timegm
+from bluebottle.clients import properties
 
 import mock
 from captcha import client
@@ -9,6 +12,8 @@ from django.core.urlresolvers import reverse
 from django.db import connection
 from django.test.utils import override_settings
 from rest_framework import status
+
+from rest_framework_jwt.settings import api_settings
 
 from bluebottle.members.models import MemberPlatformSettings, UserActivity, Member
 from bluebottle.test.factory_models.accounts import BlueBottleUserFactory
@@ -35,6 +40,52 @@ class LoginTestCase(BluebottleTestCase):
         )
 
         self.assertEqual(current_user_response.status_code, status.HTTP_200_OK)
+
+    def test_expired_token(self):
+        response = self.client.post(
+            reverse('token-auth'), {'email': self.email, 'password': self.password}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        token = response.json()['token']
+
+        with mock.patch('jwt.api_jwt.datetime') as mock_datetime:
+            mock_datetime.utcnow = mock.Mock(
+                return_value=datetime.utcnow() + timedelta(days=8)
+            )
+
+            current_user_response = self.client.get(
+                reverse('user-current'), token='JWT {}'.format(token)
+            )
+
+            self.assertEqual(current_user_response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_expired_token_exp_in_properties(self):
+        properties.JWT_EXPIRATION_DELTA = timedelta(hours=1)
+
+        response = self.client.post(
+            reverse('token-auth'), {'email': self.email, 'password': self.password}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        token = response.json()['token']
+
+        current_user_response = self.client.get(
+            reverse('user-current'), token='JWT {}'.format(token)
+        )
+
+        self.assertEqual(current_user_response.status_code, status.HTTP_200_OK)
+
+        with mock.patch('jwt.api_jwt.datetime') as mock_datetime:
+            mock_datetime.utcnow = mock.Mock(
+                return_value=datetime.utcnow() + timedelta(minutes=61)
+            )
+
+            current_user_response = self.client.get(
+                reverse('user-current'), token='JWT {}'.format(token)
+            )
+
+            self.assertEqual(current_user_response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_login_failed(self):
         response = self.client.post(
@@ -654,3 +705,32 @@ class UserActivityTest(BluebottleTestCase):
             len(activity.path), 200
         )
         self.assertTrue(activity.path.startswith('/aaaaaaa'))
+
+
+class RefreshTokenTest(BluebottleTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.user = BlueBottleUserFactory.create()
+
+        jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
+        jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER
+
+        payload = jwt_payload_handler(self.user)
+        payload['exp'] = datetime.utcnow() + properties.JWT_EXPIRATION_DELTA - timedelta(minutes=35)
+        payload['orig_iat'] = timegm((datetime.now() - timedelta(minutes=35)).utctimetuple())
+
+        token = jwt_encode_handler(payload)
+
+        self.token = "JWT {0}".format(token)
+
+        self.url = reverse('settings')
+
+    def test_refresh(self):
+        response = self.client.get(self.url, token=self.token)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        new_token = response['Refresh-Token']
+
+        response = self.client.get(reverse('user-current'), token=new_token)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()['id'], self.user.pk)

--- a/bluebottle/members/utils.py
+++ b/bluebottle/members/utils.py
@@ -1,6 +1,46 @@
+from datetime import datetime
+from calendar import timegm
 from builtins import str
 from bluebottle.clients import properties
 
 
 def get_jwt_secret(user):
     return properties.SECRET_KEY + (str(user.last_logout) if user.last_logout else '')
+
+
+import uuid
+from rest_framework_jwt.compat import get_username
+from rest_framework_jwt.compat import get_username_field
+from rest_framework_jwt.settings import api_settings
+
+
+def jwt_payload_handler(user):
+    username_field = get_username_field()
+    username = get_username(user)
+
+    payload = {
+        'user_id': user.pk,
+        'username': username,
+        'exp': datetime.utcnow() + properties.JWT_EXPIRATION_DELTA
+    }
+    if hasattr(user, 'email'):
+        payload['email'] = user.email
+    if isinstance(user.pk, uuid.UUID):
+        payload['user_id'] = str(user.pk)
+
+    payload[username_field] = username
+
+    # Include original issued at time for a brand new token,
+    # to allow token refresh
+    if api_settings.JWT_ALLOW_REFRESH:
+        payload['orig_iat'] = timegm(
+            datetime.utcnow().utctimetuple()
+        )
+
+    if api_settings.JWT_AUDIENCE is not None:
+        payload['aud'] = api_settings.JWT_AUDIENCE
+
+    if api_settings.JWT_ISSUER is not None:
+        payload['iss'] = api_settings.JWT_ISSUER
+
+    return payload

--- a/bluebottle/settings/base.py
+++ b/bluebottle/settings/base.py
@@ -186,21 +186,21 @@ if not DEBUG:
 
 
 JWT_AUTH = {
-    'JWT_EXPIRATION_DELTA': datetime.timedelta(days=7),
     'JWT_LEEWAY': 0,
     'JWT_VERIFY': True,
     'JWT_VERIFY_EXPIRATION': True,
-    'JWT_ALLOW_TOKEN_RENEWAL': True,
+    'JWT_ALLOW_REFRESH': True,
     # After the renewal limit it isn't possible to request a token refresh
     # => time token first created + renewal limit.
-    'JWT_TOKEN_RENEWAL_LIMIT': datetime.timedelta(days=90),
     'JWT_GET_USER_SECRET_KEY': 'bluebottle.members.utils.get_jwt_secret',
-
+    'JWT_PAYLOAD_HANDLER': 'bluebottle.members.utils.jwt_payload_handler',
 }
 
 # Time between attempts to refresh the jwt token automatically on standard request
 # TODO: move this setting into the JWT_AUTH settings.
 JWT_TOKEN_RENEWAL_DELTA = datetime.timedelta(minutes=30)
+JWT_TOKEN_RENEWAL_LIMIT = datetime.timedelta(days=90)
+JWT_EXPIRATION_DELTA = datetime.timedelta(days=7)
 
 # List of paths to ignore for locale redirects
 LOCALE_REDIRECT_IGNORE = ('/docs', '/go', '/api',


### PR DESCRIPTION
Fix RefreshTokenMiddleware. Make sure we an refresh tokens after
issuing.

If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
