### PR TITLE
Do not return configuration when platform is closed and user is not

### DIFF
--- a/bluebottle/clients/tests/test_api.py
+++ b/bluebottle/clients/tests/test_api.py
@@ -276,10 +276,11 @@ class TestPlatformSettingsApi(BluebottleTestCase):
                 'platform': {
                     'members': {
                         'closed': True,
-                        'confirm_signup': False,
-                        'email_domain': None,
+                        'background': '',
                         'login_methods': ['password'],
-                        'session_only': False
+                        'session_only': False,
+                        'email_domain': None,
+                        'confirm_signup': False,
                     }
                 }
             }

--- a/bluebottle/clients/tests/test_api.py
+++ b/bluebottle/clients/tests/test_api.py
@@ -12,6 +12,7 @@ from bluebottle.cms.models import SitePlatformSettings
 from bluebottle.funding.models import FundingPlatformSettings
 from bluebottle.initiatives.models import InitiativePlatformSettings
 from bluebottle.notifications.models import NotificationPlatformSettings
+from bluebottle.members.models import MemberPlatformSettings
 from bluebottle.test.factory_models.accounts import BlueBottleUserFactory
 from bluebottle.test.utils import BluebottleTestCase
 
@@ -237,3 +238,39 @@ class TestPlatformSettingsApi(BluebottleTestCase):
 
         response = self.client.get(self.settings_url)
         self.assertEqual(response.data['platform']['funding']['allow_anonymous_rewards'], True)
+
+    def test_member_platform_settings(self):
+        MemberPlatformSettings.objects.create(
+            closed=False,
+            require_consent=True
+        )
+
+        response = self.client.get(self.settings_url)
+        self.assertEqual(response.data['platform']['members']['closed'], False)
+        self.assertEqual(response.data['platform']['members']['require_consent'], True)
+
+    def test_member_platform_settings_closed(self):
+        MemberPlatformSettings.objects.create(
+            closed=True,
+            require_consent=True,
+        )
+
+        user = BlueBottleUserFactory.create()
+        user_token = "JWT {0}".format(user.get_jwt_token())
+
+        response = self.client.get(self.settings_url, token=user_token)
+        self.assertEqual(response.data['platform']['members']['closed'], True)
+        self.assertEqual(response.data['platform']['members']['require_consent'], True)
+
+    def test_member_platform_settings_closed_anonymous(self):
+        MemberPlatformSettings.objects.create(
+            closed=True,
+            require_consent=True,
+        )
+
+        response = self.client.get(self.settings_url)
+
+        self.assertEqual(
+            response.data,
+            {'platform': {'members': {'closed': True}}}
+        )

--- a/bluebottle/clients/tests/test_api.py
+++ b/bluebottle/clients/tests/test_api.py
@@ -272,5 +272,15 @@ class TestPlatformSettingsApi(BluebottleTestCase):
 
         self.assertEqual(
             response.data,
-            {'platform': {'members': {'closed': True}}}
+            {
+                'platform': {
+                    'members': {
+                        'closed': True,
+                        'confirm_signup': False,
+                        'email_domain': None,
+                        'login_methods': ['password'],
+                        'session_only': False
+                    }
+                }
+            }
         )

--- a/bluebottle/clients/views.py
+++ b/bluebottle/clients/views.py
@@ -16,9 +16,20 @@ class SettingsView(views.APIView):
         Return settings
         """
         obj = get_public_properties(request)
-        if obj['platform']['members']['closed'] and not request.user.is_authenticated:
+
+        member_settings = obj['platform']['members']
+        if member_settings['closed'] and not request.user.is_authenticated:
             obj = {
-                'platform': {'members': {'closed': True}}
+                'platform': {
+                    'members': {
+                        'closed': member_settings['closed'],
+                        'background': member_settings['background'],
+                        'login_methods': member_settings['login_methods'],
+                        'session_only': member_settings['session_only'],
+                        'email_domain': member_settings['email_domain'],
+                        'confirm_signup': member_settings['confirm_signup'],
+                    }
+                }
             }
 
         return response.Response(obj)

--- a/bluebottle/clients/views.py
+++ b/bluebottle/clients/views.py
@@ -16,4 +16,9 @@ class SettingsView(views.APIView):
         Return settings
         """
         obj = get_public_properties(request)
+        if obj['platform']['members']['closed'] and not request.user.is_authenticated:
+            obj = {
+                'platform': {'members': {'closed': True}}
+            }
+
         return response.Response(obj)


### PR DESCRIPTION
authenticated.

If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
