### PR TITLE
Show labels for mutliple select checkboxes in admin

### DIFF
--- a/bluebottle/initiatives/tests/test_admin.py
+++ b/bluebottle/initiatives/tests/test_admin.py
@@ -256,3 +256,19 @@ class TestThemeAdmin(BluebottleAdminTestCase):
         url = reverse('admin:initiatives_theme_changelist')
         response = self.app.get(url, user=self.staff_member)
         self.assertEqual(response.status, '200 OK')
+
+
+class TestInitiativePlatformSettingsAdmin(BluebottleAdminTestCase):
+
+    extra_environ = {}
+    csrf_checks = False
+    setup_auth = True
+
+    def test_admin_open_initiative_disabled(self):
+        # Check multiple input shows labels
+        url = reverse('admin:initiatives_initiativeplatformsettings_changelist')
+        self.app.set_user(self.superuser)
+        page = self.app.get(url)
+        input_html = page.html.find('div', {'class': 'field-activity_types'}).text
+        self.assertTrue('Deed' in input_html)
+        self.assertTrue('Funding' in input_html)

--- a/bluebottle/utils/templates/django/forms/widgets/input_option.html
+++ b/bluebottle/utils/templates/django/forms/widgets/input_option.html
@@ -2,6 +2,7 @@
 {% if wrap_label %}
     <label{% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>
 {% endif %}
-{% if wrap_label %} 
-    {{ widget.label }}</label>
+{{ widget.label }}
+{% if wrap_label %}
+    </label>
 {% endif %}


### PR DESCRIPTION
If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
