### PR TITLE
Make organization fields except for name optional

### DIFF
--- a/bluebottle/initiatives/tests/test_api.py
+++ b/bluebottle/initiatives/tests/test_api.py
@@ -27,7 +27,6 @@ from bluebottle.files.tests.factories import ImageFactory
 from bluebottle.test.factory_models.accounts import BlueBottleUserFactory
 from bluebottle.test.factory_models.geo import GeolocationFactory, LocationFactory
 from bluebottle.test.factory_models.projects import ThemeFactory
-from bluebottle.test.factory_models.organizations import OrganizationFactory
 from bluebottle.test.utils import JSONAPITestClient, BluebottleTestCase
 
 
@@ -178,38 +177,6 @@ class InitiativeListAPITestCase(InitiativeAPITestCase):
         data = response.json()
         self.assertTrue(
             '/data/attributes/title' in (error['source']['pointer'] for error in data['data']['meta']['errors'])
-        )
-
-    def test_create_validation_organization_website(self):
-        organization = OrganizationFactory.create(website='')
-
-        data = {
-            'data': {
-                'type': 'initiatives',
-                'attributes': {
-                    'title': 'Some title',
-                    'has_organization': True
-                },
-                'relationships': {
-                    'organization': {
-                        'data': {
-                            'type': 'organizations',
-                            'id': organization.pk
-                        },
-                    }
-                }
-
-            }
-        }
-        response = self.client.post(
-            self.url,
-            json.dumps(data),
-            user=self.owner
-        )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        organization = get_include(response, 'organizations')
-        self.assertTrue(
-            '/data/attributes/website' in (error['source']['pointer'] for error in organization['meta']['required'])
         )
 
     def test_create_with_location(self):

--- a/bluebottle/initiatives/tests/test_states.py
+++ b/bluebottle/initiatives/tests/test_states.py
@@ -115,9 +115,9 @@ class InitiativeReviewStateMachineTests(BluebottleTestCase):
             self.initiative.status, ReviewStateMachine.draft.value
         )
 
-        self.assertRaises(
-            TransitionNotPossible,
-            self.initiative.states.submit
+        self.initiative.states.submit()
+        self.assertEqual(
+            self.initiative.status, ReviewStateMachine.submitted.value
         )
 
     def test_has_organization(self):

--- a/bluebottle/organizations/models.py
+++ b/bluebottle/organizations/models.py
@@ -46,7 +46,7 @@ class Organization(ValidatedModelMixin, AnonymizationMixin, models.Model):
         ]
     )
 
-    required_fields = ['name', 'website']
+    required_fields = ['name']
 
     def __str__(self):
         return self.name
@@ -76,7 +76,7 @@ class OrganizationContact(ValidatedModelMixin, models.Model):
     created = models.DateTimeField(_('created'), auto_now_add=True)
     updated = models.DateTimeField(_('updated'), auto_now=True)
 
-    required_fields = ['name', 'email']
+    required_fields = []
 
     class Meta(object):
         verbose_name = _('Partner Organization Contact')


### PR DESCRIPTION
If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
