### PR TITLE
Add slot to included resources for date activity detail. This should …

### DIFF
--- a/bluebottle/time_based/serializers.py
+++ b/bluebottle/time_based/serializers.py
@@ -278,6 +278,7 @@ class DateActivitySerializer(DateActivitySlotInfoMixin, TimeBasedBaseSerializer)
         included_resources = TimeBasedBaseSerializer.JSONAPIMeta.included_resources + [
             'my_contributor',
             'my_contributor.slots',
+            'my_contributor.slots.slot',
         ]
 
     included_serializers = dict(
@@ -285,6 +286,7 @@ class DateActivitySerializer(DateActivitySlotInfoMixin, TimeBasedBaseSerializer)
         **{
             'my_contributor': 'bluebottle.time_based.serializers.DateParticipantSerializer',
             'my_contributor.slots': 'bluebottle.time_based.serializers.SlotParticipantSerializer',
+            'my_contributor.slots.slot': 'bluebottle.time_based.serializers.DateActivitySlotSerializer',
         }
     )
 

--- a/bluebottle/time_based/tests/test_api.py
+++ b/bluebottle/time_based/tests/test_api.py
@@ -638,6 +638,19 @@ class DateDetailAPIViewTestCase(TimeBasedDetailAPIViewTestCase, BluebottleTestCa
             )
         )
 
+    def test_get_my_contributor(self):
+        participant = DateParticipantFactory.create(activity=self.activity)
+
+        response = self.client.get(self.url, user=participant.user)
+
+        included_participant = get_first_included_by_type(response, 'contributors/time-based/date-participants')
+        included_slot = get_first_included_by_type(response, 'activities/time-based/date-slots')
+
+        self.assertEqual(str(participant.pk), included_participant['id'])
+        self.assertEqual(
+            str(participant.slot_participants.first().slot.pk), included_slot['id']
+        )
+
     def test_matching_all(self):
         self.activity.initiative.states.submit(save=True)
         self.activity.initiative.states.approve(save=True)


### PR DESCRIPTION
…make it possible to add all slots a user has joined to he top of the grouped-slots-list

If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
