### PR TITLE
Make sure we don't get errors with duplicated files

### DIFF
--- a/bluebottle/files/serializers.py
+++ b/bluebottle/files/serializers.py
@@ -46,7 +46,7 @@ class PrivateDocumentField(DocumentField):
         parent = self.parent.instance
         # We might have a list when getting this for included serializers
         if isinstance(parent, (QuerySet, tuple, list)):
-            parent = self.context['view'].get_queryset().get(**{self.field_name: value.pk})
+            parent = self.context['view'].get_queryset().filter(**{self.field_name: value.pk}).first()
 
         if not self.has_parent_permissions(parent):
             return None

--- a/bluebottle/time_based/tests/test_api.py
+++ b/bluebottle/time_based/tests/test_api.py
@@ -1940,6 +1940,18 @@ class RelatedParticipantsAPIViewTestCase():
         included_documents = self.included_by_type(self.response, 'private-documents')
         self.assertEqual(len(included_documents), 10)
 
+    def test_get_with_duplicate_files(self):
+        file = PrivateDocumentFactory.create(owner=self.participants[2].user)
+        self.participants[2].document = file
+        self.participants[2].save()
+        self.participants[3].document = file
+        self.participants[3].save()
+        self.response = self.client.get(self.url, user=self.activity.owner)
+        self.assertEqual(self.response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(self.response.json()['data']), 10)
+        included_documents = self.included_by_type(self.response, 'private-documents')
+        self.assertEqual(len(included_documents), 9)
+
     def test_get_anonymous(self):
         self.response = self.client.get(self.url)
 


### PR DESCRIPTION
Internal Server Error: /api/time-based/period/850/participants

MultipleObjectsReturned at /api/time-based/period/850/participants
get() returned more than one PeriodParticipant -- it returned 2!


https://onepercentclub.atlassian.net/browse/BB-18915