### PR TITLE
Test initiative admin with wrong id doesn't crash

### DIFF
--- a/bluebottle/initiatives/tests/test_admin.py
+++ b/bluebottle/initiatives/tests/test_admin.py
@@ -55,6 +55,20 @@ class TestInitiativeAdmin(BluebottleAdminTestCase):
         self.assertContains(response, 'Offices')
         self.assertContains(response, 'Impact location')
 
+    def test_initiative_admin_wrong_id(self):
+        image = ImageFactory.create()
+        self.initiative.image = image
+        self.initiative.save()
+        self.client.force_login(self.superuser)
+        admin_url = reverse('admin:initiatives_initiative_change',
+                            args=(123456789,))
+        response = self.client.get(admin_url)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/en/admin/')
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(str(messages[0]), 'Initiative with ID "123456789" doesn\'t exist. Perhaps it was deleted?')
+
     def test_initiative_open(self):
         LocationFactory.create()
         self.initiative.is_open = True

--- a/bluebottle/notifications/admin.py
+++ b/bluebottle/notifications/admin.py
@@ -49,14 +49,14 @@ class NotificationAdminMixin(object):
             with transaction.atomic(using=router.db_for_write(self.model)):
                 return self._changeform_view(request, object_id, form_url, extra_context)
 
-        obj = self.model.objects.get(pk=object_id)
+        obj = self.get_object(request, object_id)
         new = None
         ModelForm = self.get_form(request, obj)
 
         if request.method == 'POST':
             form = ModelForm(request.POST, request.FILES, instance=obj)
             new = self.save_form(request, form, change=True)
-        old = self.model.objects.get(pk=object_id)
+        old = self.get_object(request, object_id)
 
         confirm = request.POST.get('confirm', False)
         send_messages = request.POST.get('send_messages', True)


### PR DESCRIPTION
If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
