### PR TITLE
Make sure that activity finishes when all participants are in other

### DIFF
--- a/bluebottle/time_based/triggers.py
+++ b/bluebottle/time_based/triggers.py
@@ -605,7 +605,7 @@ class DateActivitySlotTriggers(ActivitySlotTriggers):
                     TimeBasedStateMachine.succeed,
                     conditions=[
                         all_slots_finished,
-                        has_accepted_participants
+                        activity_has_accepted_participants
                     ]
                 ),
                 RelatedTransitionEffect(


### PR DESCRIPTION
slots.

BB-19108 #fixes

If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
