### PR TITLE
When sorting on activity date, sort on activity status first.

### DIFF
--- a/bluebottle/initiatives/documents.py
+++ b/bluebottle/initiatives/documents.py
@@ -13,6 +13,16 @@ from bluebottle.deeds.models import Deed
 from bluebottle.members.models import Member
 
 
+SCORE_MAP = {
+    'open': 1,
+    'running': 0.7,
+    'full': 0.6,
+    'succeeded': 0.5,
+    'partially_funded': 0.5,
+    'refundend': 0.3,
+}
+
+
 # The name of your index
 initiative = MultiTenantIndex('initiatives')
 # See Elasticsearch Indices API reference for available settings
@@ -66,6 +76,7 @@ class InitiativeDocument(Document):
         'id': fields.LongField(),
         'title': fields.KeywordField(),
         'activity_date': fields.DateField(),
+        'status_score': fields.FloatField()
     })
 
     place = fields.NestedField(properties={
@@ -114,7 +125,8 @@ class InitiativeDocument(Document):
             {
                 'id': activity.pk,
                 'title': activity.title,
-                'activity_date': activity.activity_date
+                'activity_date': activity.activity_date,
+                'status_score': SCORE_MAP[activity.status],
             } for activity in instance.activities.filter(
                 status__in=(
                     'succeeded',

--- a/bluebottle/initiatives/filters.py
+++ b/bluebottle/initiatives/filters.py
@@ -11,6 +11,13 @@ class InitiativeSearchFilter(ElasticSearchFilter):
     sort_fields = {
         'date': ('-created', ),
         'activity_date': ({
+            'activities.status_score': {
+                'order': 'desc',
+                'mode': 'max',
+                'nested': {
+                    'path': 'activities'
+                }
+            },
             'activities.activity_date': {
                 'order': 'desc',
                 'mode': 'max',

--- a/bluebottle/initiatives/tests/test_api.py
+++ b/bluebottle/initiatives/tests/test_api.py
@@ -1047,6 +1047,20 @@ class InitiativeListSearchAPITestCase(ESTestCase, InitiativeAPITestCase):
             deadline=(now() + datetime.timedelta(days=9)).date()
         )
 
+        fourth = InitiativeFactory.create(status='approved')
+        PeriodActivityFactory.create(
+            initiative=fourth,
+            status='succeeded',
+            deadline=(now() + datetime.timedelta(days=7)).date()
+        )
+
+        fifth = InitiativeFactory.create(status='approved')
+        PeriodActivityFactory.create(
+            initiative=fourth,
+            status='succeeded',
+            deadline=(now() + datetime.timedelta(days=8)).date()
+        )
+
         response = self.client.get(
             self.url + '?sort=activity_date',
             HTTP_AUTHORIZATION="JWT {0}".format(self.owner.get_jwt_token())
@@ -1054,10 +1068,12 @@ class InitiativeListSearchAPITestCase(ESTestCase, InitiativeAPITestCase):
 
         data = json.loads(response.content)
 
-        self.assertEqual(data['meta']['pagination']['count'], 3)
+        self.assertEqual(data['meta']['pagination']['count'], 5)
         self.assertEqual(data['data'][0]['id'], str(third.pk))
         self.assertEqual(data['data'][1]['id'], str(first.pk))
         self.assertEqual(data['data'][2]['id'], str(second.pk))
+        self.assertEqual(data['data'][3]['id'], str(fourth.pk))
+        self.assertEqual(data['data'][4]['id'], str(fifth.pk))
 
 
 class InitiativeReviewTransitionListAPITestCase(InitiativeAPITestCase):


### PR DESCRIPTION
If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
