### PR TITLE
Make sure we load the complete participant when applying

### DIFF
--- a/bluebottle/time_based/serializers.py
+++ b/bluebottle/time_based/serializers.py
@@ -685,6 +685,7 @@ class DateParticipantSerializer(ParticipantSerializer):
         included_resources = [
             'user',
             'document',
+            'slots',
             'activity'
         ]
         resource_name = 'contributors/time-based/date-participants'

--- a/bluebottle/time_based/tests/test_api.py
+++ b/bluebottle/time_based/tests/test_api.py
@@ -1484,10 +1484,10 @@ class ParticipantListViewTestCase():
         }
 
     def test_create(self):
-        response = self.client.post(self.url, json.dumps(self.data), user=self.user)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.response = self.client.post(self.url, json.dumps(self.data), user=self.user)
+        self.assertEqual(self.response.status_code, status.HTTP_201_CREATED)
 
-        data = response.json()['data']
+        data = self.response.json()['data']
         self.assertEqual(
             data['relationships']['user']['data']['id'],
             str(self.user.pk)
@@ -1559,9 +1559,10 @@ class ParticipantListViewTestCase():
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-    def get_participants(self):
-        response = self.client.get(self.url, json.dumps(self.data))
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+    def test_get_participants(self):
+        self.test_create()
+        self.response = self.client.get(self.url)
+        self.assertEqual(self.response.status_code, status.HTTP_200_OK)
 
 
 class DateParticipantListAPIViewTestCase(ParticipantListViewTestCase, BluebottleTestCase):
@@ -1573,6 +1574,16 @@ class DateParticipantListAPIViewTestCase(ParticipantListViewTestCase, Bluebottle
     application_type = 'contributions/time-based/date-participants'
     url_name = 'date-participant-list'
     participant_type = 'contributors/time-based/date-participants'
+
+    def test_create(self):
+        super().test_create()
+        types = [included['type'] for included in self.response.json()['included']]
+        self.assertTrue('contributors/time-based/slot-participants' in types)
+
+    def test_get_participants(self):
+        super().test_get_participants()
+        types = [included['type'] for included in self.response.json()['included']]
+        self.assertFalse('contributors/time-based/slot-participants' in types)
 
 
 class PeriodParticipantListAPIViewTestCase(ParticipantListViewTestCase, BluebottleTestCase):

--- a/bluebottle/time_based/views.py
+++ b/bluebottle/time_based/views.py
@@ -29,6 +29,7 @@ from bluebottle.time_based.serializers import (
     PeriodTransitionSerializer,
     PeriodParticipantSerializer,
     DateParticipantSerializer,
+    DateParticipantListSerializer,
     DateParticipantTransitionSerializer,
     PeriodParticipantTransitionSerializer,
     TimeContributionSerializer,
@@ -263,7 +264,12 @@ class ParticipantList(JsonApiViewMixin, ListCreateAPIView):
 
 class DateParticipantList(ParticipantList):
     queryset = DateParticipant.objects.all()
-    serializer_class = DateParticipantSerializer
+
+    def get_serializer_class(self):
+        if self.request.method == 'POST':
+            return DateParticipantSerializer
+        else:
+            return DateParticipantListSerializer
 
 
 class PeriodParticipantList(ParticipantList):


### PR DESCRIPTION
If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
