### PR TITLE
Prefer white when selecting text_color.

### DIFF
--- a/bluebottle/segments/models.py
+++ b/bluebottle/segments/models.py
@@ -129,16 +129,15 @@ class Segment(models.Model):
 
     @property
     def text_color(self):
-        options = {
-            _('white'): (1, 1, 1),
-            _('grey'): (0.2890625, 0.2890625, 0.2890625)
-        }
         rgb_background_color = [c / 256.0 for c in ImageColor.getcolor(self.background_color, 'RGB')]
+        white = (1, 1, 1)
 
-        return max(
-            options.items(),
-            key=lambda option: contrast.rgb(rgb_background_color, option[1])
-        )[0]
+        contrast_with_white = contrast.rgb(rgb_background_color, white)
+
+        if contrast.passes_AA(contrast_with_white, large=True):
+            return 'white'
+        else:
+            return 'grey'
 
     def __str__(self):
         return u'{}: {}'.format(self.segment_type.name, self.name)

--- a/bluebottle/segments/tests/test_unit.py
+++ b/bluebottle/segments/tests/test_unit.py
@@ -24,3 +24,17 @@ class TestSegmentModel(BluebottleTestCase):
         segment.save()
 
         self.assertEqual(segment.alternate_names, ['test'])
+
+    def test_text_color(self):
+        segment = Segment(
+            segment_type=self.type,
+            name='test',
+        )
+
+        for color, text_color in [
+            ('#ffffff', 'grey'),
+            ('#000000', 'white'),
+            ('#ff4422', 'white')
+        ]:
+            segment.background_color = color
+            self.assertEqual(segment.text_color, text_color)


### PR DESCRIPTION
Use WCAG20 guidelines to select the right color

BB-19511 #resolve

If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
