### PR TITLE
Make signup token expire after 24 hours

### DIFF
--- a/bluebottle/bb_accounts/views.py
+++ b/bluebottle/bb_accounts/views.py
@@ -222,7 +222,7 @@ class SignUpTokenConfirmation(generics.UpdateAPIView):
         try:
             signer = TimestampSigner()
             member = self.queryset.get(
-                pk=signer.unsign(self.kwargs['pk'], max_age=timedelta(hours=2))
+                pk=signer.unsign(self.kwargs['pk'], max_age=timedelta(hours=24))
             )
 
             if member.is_active:

--- a/bluebottle/members/tests/test_api.py
+++ b/bluebottle/members/tests/test_api.py
@@ -487,7 +487,7 @@ class ConfirmSignUpTestCase(BluebottleTestCase):
 
         current_time = time.time()
 
-        with mock.patch('time.time', return_value=current_time - (3 * 60 * 60)):
+        with mock.patch('time.time', return_value=current_time - (25 * 60 * 60)):
             token = TimestampSigner().sign(member.pk)
 
         response = self.client.put(


### PR DESCRIPTION
If applicable

- [ ] Added translatable strings to `server-deployment`
- [ ] Added translations to `sever-deployment`
