### PR TITLE
Ignore duplicate emails in scim when user does not have a

### DIFF
--- a/bluebottle/scim/serializers.py
+++ b/bluebottle/scim/serializers.py
@@ -154,7 +154,7 @@ class SCIMMemberSerializer(serializers.ModelSerializer):
         allow_blank=False,
         validators=[
             validators.UniqueValidator(
-                queryset=Member.objects.all(), lookup='iexact'
+                queryset=Member.objects.filter(scim_external_id__isnull=False), lookup='iexact'
             )
         ]
     )

--- a/bluebottle/scim/tests/test_api.py
+++ b/bluebottle/scim/tests/test_api.py
@@ -576,7 +576,9 @@ class SCIMUserListTest(AuthenticatedSCIMEndpointTestCaseMixin, BluebottleTestCas
         Test creating a user twice request
         """
         remote_id = '123'
-        user = BlueBottleUserFactory.create(remote_id=remote_id, scim_external_id=None)
+        user = BlueBottleUserFactory.create(
+            email='test@example.com', remote_id=remote_id, scim_external_id=None
+        )
 
         data = {
             'schemas': ['urn:ietf:params:scim:schemas:core:2.0:User'],


### PR DESCRIPTION
`scim_external_id` yet.