### PR TITLE
Use a smaller delay for the change message. This way we avoid a race …

### DIFF
--- a/bluebottle/time_based/messages.py
+++ b/bluebottle/time_based/messages.py
@@ -376,7 +376,7 @@ class ParticipantChangedNotification(TimeBasedInfoMixin, TransitionMessage):
         'title': 'activity.title',
     }
 
-    delay = 60
+    delay = 55
 
     @property
     def action_link(self):

--- a/bluebottle/time_based/tests/test_triggers.py
+++ b/bluebottle/time_based/tests/test_triggers.py
@@ -1214,13 +1214,13 @@ class DateParticipantTriggerTestCase(ParticipantTriggerTestCase, BluebottleTestC
 
 
 @mock.patch.object(
-    ParticipantJoinedNotification, 'delay', 1
+    ParticipantJoinedNotification, 'delay', 2
 )
 @mock.patch.object(
     ParticipantChangedNotification, 'delay', 1
 )
 @mock.patch.object(
-    ParticipantAppliedNotification, 'delay', 1
+    ParticipantAppliedNotification, 'delay', 2
 )
 class DateParticipantTriggerCeleryTestCase(CeleryTestCase):
     factory = DateActivityFactory
@@ -1263,7 +1263,7 @@ class DateParticipantTriggerCeleryTestCase(CeleryTestCase):
             activity=self.activity
         )
 
-        time.sleep(2)
+        time.sleep(3)
 
         self.assertEqual(len(mail.outbox), 2)
         self.assertEqual(
@@ -1296,7 +1296,7 @@ class DateParticipantTriggerCeleryTestCase(CeleryTestCase):
             for slot in self.slots
         ]
 
-        time.sleep(2)
+        time.sleep(3)
 
         self.assertEqual(len(mail.outbox), 2)
         self.assertEqual(
@@ -1326,7 +1326,7 @@ class DateParticipantTriggerCeleryTestCase(CeleryTestCase):
             for slot in self.slots
         ]
 
-        time.sleep(2)
+        time.sleep(3)
 
         self.assertEqual(len(mail.outbox), 2)
         self.assertEqual(
@@ -1341,13 +1341,13 @@ class DateParticipantTriggerCeleryTestCase(CeleryTestCase):
     def test_change_free(self):
         self.test_join_free()
 
-        time.sleep(2)
+        time.sleep(3)
         mail.outbox = []
 
         for slot_participant in self.slot_participants[:-1]:
             slot_participant.states.withdraw(save=True)
 
-        time.sleep(2)
+        time.sleep(3)
 
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(
@@ -1363,13 +1363,13 @@ class DateParticipantTriggerCeleryTestCase(CeleryTestCase):
     def test_withdraw_free(self):
         self.test_join_free()
 
-        time.sleep(2)
+        time.sleep(3)
         mail.outbox = []
 
         for slot_participant in self.slot_participants:
             slot_participant.states.withdraw(save=True)
 
-        time.sleep(2)
+        time.sleep(3)
 
         self.assertEqual(len(mail.outbox), 2)
         self.assertEqual(


### PR DESCRIPTION
…condition where the changed message is accidentally send.