### PR TITLE
Only allow json content type for login endpoint.

### DIFF
--- a/bluebottle/auth/tests/test_api.py
+++ b/bluebottle/auth/tests/test_api.py
@@ -62,16 +62,3 @@ class UserTokenTestCase(BluebottleTestCase):
             self.assertTrue(
                 'Authorization failed: {} 127.0.0.1'.format(self.user.email) in error.call_args[0]
             )
-
-    def test_login_failure_form_data_is_logged(self):
-        with patch.object(authorization_logger, 'error') as error:
-            response = self.client.post(
-                reverse("token-auth"),
-                {'email': self.user.email, 'password': 'wrong'},
-                format='multipart'
-            )
-            self.assertEqual(response.status_code, 400)
-
-            self.assertTrue(
-                'Authorization failed: {} 127.0.0.1'.format(self.user.email) in error.call_args[0]
-            )

--- a/bluebottle/bb_accounts/views.py
+++ b/bluebottle/bb_accounts/views.py
@@ -188,6 +188,7 @@ class Logout(generics.CreateAPIView):
 
     """
     permission_classes = (IsAuthenticated, )
+    parser_classes = (parsers.JSONParser, )
 
     def create(self, request, *args, **kwargs):
         if self.request.user.is_authenticated:

--- a/bluebottle/bb_accounts/views.py
+++ b/bluebottle/bb_accounts/views.py
@@ -13,7 +13,7 @@ from django.utils.http import base36_to_int, int_to_base36
 from django.utils.translation import gettext_lazy as _
 from django.utils import timezone
 
-from rest_framework import status, response, generics
+from rest_framework import status, response, generics, parsers
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.exceptions import PermissionDenied, NotAuthenticated, ValidationError
 
@@ -60,6 +60,7 @@ class AxesObtainJSONWebToken(ObtainJSONWebTokenView):
     Returns a JSON Web Token that can be used for authenticated requests.
     """
     serializer_class = AxesJSONWebTokenSerializer
+    parser_classes = (parsers.JSONParser, )
 
 
 class CaptchaVerification(JsonApiViewMixin, CreateAPIView):

--- a/bluebottle/members/tests/test_api.py
+++ b/bluebottle/members/tests/test_api.py
@@ -55,6 +55,14 @@ class LoginTestCase(BluebottleTestCase):
 
         self.assertEqual(current_user_response.status_code, status.HTTP_200_OK)
 
+    def test_login_formencoded(self):
+        response = self.client.post(
+            reverse('token-auth'),
+            {'email': self.email, 'password': self.password},
+            format='multipart'
+        )
+        self.assertEqual(response.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
+
     def test_login_different_case(self):
         response = self.client.post(
             reverse('token-auth'),


### PR DESCRIPTION
This prevents csrf attacks where the attacker can secretly log the user
in.