### PR TITLE
Use the full activity serializer when loading period participants.

### DIFF
--- a/bluebottle/activities/utils.py
+++ b/bluebottle/activities/utils.py
@@ -292,7 +292,6 @@ class BaseActivityListSerializer(ModelSerializer):
     status = FSMField(read_only=True)
     permissions = ResourcePermissionField('activity-detail', view_args=('pk',))
     owner = AnonymizedResourceRelatedField(read_only=True)
-    contributor_count = serializers.SerializerMethodField()
     is_follower = serializers.SerializerMethodField()
     type = serializers.CharField(read_only=True, source='JSONAPIMeta.resource_name')
     stats = serializers.OrderedDict(read_only=True)

--- a/bluebottle/activities/utils.py
+++ b/bluebottle/activities/utils.py
@@ -292,6 +292,7 @@ class BaseActivityListSerializer(ModelSerializer):
     status = FSMField(read_only=True)
     permissions = ResourcePermissionField('activity-detail', view_args=('pk',))
     owner = AnonymizedResourceRelatedField(read_only=True)
+    contributor_count = serializers.SerializerMethodField()
     is_follower = serializers.SerializerMethodField()
     type = serializers.CharField(read_only=True, source='JSONAPIMeta.resource_name')
     stats = serializers.OrderedDict(read_only=True)

--- a/bluebottle/time_based/serializers.py
+++ b/bluebottle/time_based/serializers.py
@@ -760,6 +760,7 @@ class PeriodParticipantSerializer(ParticipantSerializer):
         **{
             'document': 'bluebottle.time_based.serializers.PeriodParticipantDocumentSerializer',
             'contributions': 'bluebottle.time_based.serializers.TimeContributionSerializer',
+            'activity': 'bluebottle.time_based.serializers.PeriodActivitySerializer',
         }
     )
 


### PR DESCRIPTION
This way we do not replace the full model with the list model if you are
a participant looking at the details page.