### PR TITLE
Make it possible to add teams without an owner to activities.

### DIFF
--- a/bluebottle/activities/models.py
+++ b/bluebottle/activities/models.py
@@ -302,7 +302,9 @@ class Team(TriggerMixin, models.Model):
 
     @property
     def name(self):
-        return str(_("{name}'s team").format(name=self.owner.full_name))
+        return str(_("{name}'s team").format(
+            name=self.owner.full_name if self.owner_id else _("Anonymous")
+        ))
 
     def __str__(self):
         return self.name

--- a/bluebottle/time_based/triggers.py
+++ b/bluebottle/time_based/triggers.py
@@ -1150,7 +1150,7 @@ class ParticipantTriggers(ContributorTriggers):
         ),
 
         ModelChangedTrigger(
-            'team',
+            'team_id',
             effects=[
                 NotificationEffect(
                     TeamParticipantAddedNotification,


### PR DESCRIPTION
Do not send team_participant_added message to all members when adding a
team.