### PR TITLE
Use hyperlink field instead of including all segments in the segment

### DIFF
--- a/bluebottle/segments/serializers.py
+++ b/bluebottle/segments/serializers.py
@@ -1,6 +1,7 @@
 from builtins import object
 
 from rest_framework import serializers
+from rest_framework_json_api.relations import HyperlinkedRelatedField
 
 from bluebottle.activities.models import Activity
 from bluebottle.activities.utils import get_stats_for_activities
@@ -12,10 +13,12 @@ from bluebottle.utils.fields import SafeField
 
 class SegmentTypeSerializer(serializers.ModelSerializer):
     name = serializers.CharField(required=False)
-
-    included_serializers = {
-        'segments': 'bluebottle.segments.serializers.SegmentDetailSerializer',
-    }
+    segments = HyperlinkedRelatedField(
+        many=True,
+        read_only=True,
+        related_link_view_name='related-segment-detail',
+        related_link_url_kwarg='segment_type',
+    )
 
     class Meta(object):
         model = SegmentType
@@ -25,7 +28,6 @@ class SegmentTypeSerializer(serializers.ModelSerializer):
         )
 
     class JSONAPIMeta(object):
-        included_resources = ['segments', ]
         resource_name = 'segment-types'
 
 

--- a/bluebottle/segments/tests/test_api.py
+++ b/bluebottle/segments/tests/test_api.py
@@ -53,9 +53,6 @@ class SegmentTypeListAPITestCase(BluebottleTestCase):
         segment_type = SegmentType.objects.get(pk=result['id'])
 
         self.assertEqual(segment_type.name, result['attributes']['name'])
-        self.assertEqual(
-            result['relationships']['segments']['meta']['count'], 3
-        )
 
         self.assertTrue(
             result['relationships']['segments']['links']['related'].endswith(

--- a/bluebottle/segments/tests/test_api.py
+++ b/bluebottle/segments/tests/test_api.py
@@ -54,8 +54,13 @@ class SegmentTypeListAPITestCase(BluebottleTestCase):
 
         self.assertEqual(segment_type.name, result['attributes']['name'])
         self.assertEqual(
-            set(relation['id'] for relation in result['relationships']['segments']['data']),
-            set(str(segment.pk) for segment in segment_type.segments.all())
+            result['relationships']['segments']['meta']['count'], 3
+        )
+
+        self.assertTrue(
+            result['relationships']['segments']['links']['related'].endswith(
+                reverse('related-segment-detail', args=(segment_type.pk, ))
+            )
         )
 
     def test_list_anonymous(self):

--- a/bluebottle/segments/urls/api.py
+++ b/bluebottle/segments/urls/api.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 
 from bluebottle.segments.views import (
-    SegmentList, SegmentDetail, SegmentPublicDetail, SegmentTypeList
+    SegmentList, SegmentDetail, RelatedSegmentDetail, SegmentPublicDetail, SegmentTypeList
 )
 
 
@@ -15,6 +15,12 @@ urlpatterns = [
         r'^$',
         SegmentList.as_view(),
         name='segment-list'
+    ),
+
+    url(
+        r'^types/(?P<segment_type>\d+)/segments$',
+        RelatedSegmentDetail.as_view(),
+        name='related-segment-detail'
     ),
 
     url(

--- a/bluebottle/segments/views.py
+++ b/bluebottle/segments/views.py
@@ -58,6 +58,21 @@ class SegmentDetail(JsonApiViewMixin, RetrieveAPIView):
     ]
 
 
+class RelatedSegmentDetail(JsonApiViewMixin, ListAPIView):
+    serializer_class = SegmentDetailSerializer
+    queryset = Segment.objects.filter(segment_type__is_active=True).select_related('segment_type')
+
+    permission_classes = [
+        OpenSegmentOrMember,
+        TenantConditionalOpenClose,
+    ]
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+
+        return queryset.filter(segment_type_id=self.kwargs['segment_type'])
+
+
 class SegmentPublicDetail(JsonApiViewMixin, RetrieveAPIView):
     serializer_class = SegmentPublicDetailSerializer
     queryset = Segment.objects.filter(segment_type__is_active=True).select_related('segment_type')


### PR DESCRIPTION
type list.

For platforms with a lot segments this greatly improves the loading time
of the search page or required fields modal.