### PR TITLE
Remove status from activity filter types.

### DIFF
--- a/bluebottle/initiatives/models.py
+++ b/bluebottle/initiatives/models.py
@@ -260,7 +260,6 @@ class InitiativePlatformSettings(BasePlatformSettings):
         ('team_activity', _('Team activities')),
         ('theme', _('Theme')),
         ('category', _('Category')),
-        ('status', _('Status')),
         ('segments', _('Segments')),
     )
     INITIATIVE_SEARCH_FILTERS = (


### PR DESCRIPTION
Since the frontend now always filters on status, we no longer show the
filter and no longer have a need for this option.