### PR TITLE
chore: fix ratio text

### DIFF
--- a/bluebottle/cms/models.py
+++ b/bluebottle/cms/models.py
@@ -718,9 +718,9 @@ class ImagePlainTextItem(ContentItem):
     )
 
     RATIO_CHOICES = (
-        ('0.5', _("2:1 (Text twice as wide)")),
+        ('0.5', _("1:2 (Text twice as wide)")),
         ('1', _("1:1 (Equal width)")),
-        ('2', _("1:2 (Image twice as wide)")),
+        ('2', _("2:1 (Image twice as wide)")),
     )
 
     align = models.CharField(_("Picture placement"), max_length=10, choices=ALIGN_CHOICES, default="right")


### PR DESCRIPTION
In the current implementation the label "Picture / Text ratio" doesn't correspond with the listed ratio in the options. This PR fixes that

<img width="318" alt="Screenshot 2023-02-23 at 10 44 44" src="https://user-images.githubusercontent.com/10089969/220872005-1373d782-0796-4a03-82ef-0c7081c64040.png">
