### PR TITLE
Only count registered slot particpants when locking slot.

### DIFF
--- a/bluebottle/time_based/tests/test_triggers.py
+++ b/bluebottle/time_based/tests/test_triggers.py
@@ -2446,7 +2446,7 @@ class FreeSlotParticipantTriggerTestCase(BluebottleTestCase):
 
     def test_fill_slot(self):
         SlotParticipantFactory.create(slot=self.slot1, participant=self.participant)
-        self.assertStatus(self.slot1, 'open')
+        self.assertStatus(self.slot1, "open")
         participant2 = DateParticipantFactory.create(activity=self.activity)
         SlotParticipantFactory.create(slot=self.slot1, participant=participant2)
         self.assertStatus(self.slot1, 'full')
@@ -2454,6 +2454,18 @@ class FreeSlotParticipantTriggerTestCase(BluebottleTestCase):
         SlotParticipantFactory.create(slot=self.slot2, participant=self.participant)
         self.assertStatus(self.slot2, 'full')
         self.assertStatus(self.activity, 'full')
+
+    def test_do_not_fill_withdrawn(self):
+        withdrawn = SlotParticipantFactory.create(
+            slot=self.slot1, participant=self.participant
+        )
+        withdrawn.states.withdraw(save=True)
+        self.assertStatus(self.slot1, "open")
+        participant2 = DateParticipantFactory.create(activity=self.activity)
+
+        SlotParticipantFactory.create(slot=self.slot1, participant=participant2)
+        self.assertStatus(self.slot1, "open")
+        self.assertStatus(self.activity, "open")
 
     def test_fill_slot_ignores_activity_capacity(self):
         self.activity.capacity = 1

--- a/bluebottle/time_based/triggers.py
+++ b/bluebottle/time_based/triggers.py
@@ -445,7 +445,9 @@ def participant_slot_will_be_full(effect):
     """
     the slot will be filled
     """
-    participant_count = effect.instance.slot.slot_participants.filter(participant__status='accepted').count()
+    participant_count = effect.instance.slot.slot_participants.filter(
+        status="registered", participant__status="accepted"
+    ).count()
     if effect.instance.slot.capacity \
             and effect.instance.participant.status == 'accepted' \
             and participant_count + 1 >= effect.instance.slot.capacity:


### PR DESCRIPTION
This caused slots to fill up to quickly when there were withdrawn participants.