### PR TITLE
Change how inline participant list work

### DIFF
--- a/bluebottle/fsm/admin.py
+++ b/bluebottle/fsm/admin.py
@@ -126,6 +126,7 @@ class StateMachineAdminMixin(object):
         send_messages = request.POST.get('send_messages') == 'on'
         for form in formset.forms:
             if isinstance(form.instance, TriggerMixin):
+                send_messages = form.cleaned_data.get('send_messages', send_messages)
                 form.instance.execute_triggers(user=request.user, send_messages=send_messages)
 
         formset.save()

--- a/bluebottle/time_based/tests/test_participant_triggers.py
+++ b/bluebottle/time_based/tests/test_participant_triggers.py
@@ -65,8 +65,18 @@ class ParticipantTriggerTestCase:
 
     def test_withdraw(self):
         self.test_initial()
+        mail.outbox = []
         self.participant.states.withdraw(save=True)
         self.assertEqual(self.participant.status, "withdrawn")
+        self.assertEqual(len(mail.outbox), 2)
+        self.assertEqual(
+            mail.outbox[0].subject,
+            'You have withdrawn from the activity "{}"'.format(self.activity.title),
+        )
+        self.assertEqual(
+            mail.outbox[1].subject,
+            'A participant has withdrawn from your activity "{}"'.format(self.activity.title),
+        )
 
         self.assertFalse(
             self.activity.followers.filter(user=self.participant.user).exists()
@@ -98,8 +108,22 @@ class ParticipantTriggerTestCase:
 
     def test_remove(self):
         self.test_initial()
+        mail.outbox = []
         self.participant.states.remove(save=True)
         self.assertEqual(self.participant.status, "removed")
+        self.assertEqual(len(mail.outbox), 2)
+        self.assertEqual(
+            mail.outbox[0].subject,
+            'You have been removed as participant for the activity "{}"'.format(
+                self.activity.title
+            )
+        )
+        self.assertEqual(
+            mail.outbox[1].subject,
+            'A participant has been removed from your activity "{}"'.format(
+                self.activity.title
+            )
+        )
 
         self.assertFalse(
             self.activity.followers.filter(user=self.participant.user).exists()
@@ -114,6 +138,7 @@ class ParticipantTriggerTestCase:
 
     def test_readd(self):
         self.test_remove()
+        mail.outbox = []
         self.participant.states.readd(save=True)
         self.assertEqual(self.participant.status, self.expected_status)
 

--- a/bluebottle/time_based/tests/test_registration_triggers.py
+++ b/bluebottle/time_based/tests/test_registration_triggers.py
@@ -123,7 +123,7 @@ class RegistrationTriggerTestCase:
         self.assertEqual(self.activity.status, "open")
 
 
-class DeadlineRegistationTriggerTestCase(
+class DeadlineRegistrationTriggerTestCase(
     RegistrationTriggerTestCase, BluebottleTestCase
 ):
     activity_factory = DeadlineActivityFactory


### PR DESCRIPTION
1. You can't change the user for a participant
2. When adding a new participant you can :white_tick: if you want to send out messages or not

![image](https://github.com/onepercentclub/bluebottle/assets/1277572/947dd04f-2b8a-4e4d-b6dc-9ea9527ecef2)
