### PR TITLE
Anonimize anonimize-registrations

### DIFF
--- a/bluebottle/time_based/models.py
+++ b/bluebottle/time_based/models.py
@@ -997,7 +997,7 @@ class Participant(Contributor):
 
     registration = models.ForeignKey(
         'time_based.Registration',
-        on_delete=models.CASCADE,
+        on_delete=models.SET_NULL,
         blank=True,
         null=True
     )
@@ -1617,7 +1617,7 @@ class ScheduleParticipant(Participant, Contributor):
     registration = models.ForeignKey(
         'time_based.ScheduleRegistration',
         related_name='participants',
-        on_delete=models.CASCADE,
+        on_delete=models.SET_NULL,
         blank=True,
         null=True
     )
@@ -1672,7 +1672,7 @@ class TeamScheduleParticipant(Participant, Contributor):
     registration = models.ForeignKey(
         'time_based.TeamScheduleRegistration',
         related_name='participants',
-        on_delete=models.CASCADE,
+        on_delete=models.SET_NULL,
         blank=True,
         null=True
     )

--- a/bluebottle/time_based/signals.py
+++ b/bluebottle/time_based/signals.py
@@ -13,7 +13,7 @@ from bluebottle.time_based.models import (
 def update_delete_registration(sender, instance, **kwargs):
 
     try:
-        if instance.registration.participants.count() == 0:
+        if instance.registration and instance.registration.participants.count() == 0:
             instance.registration.delete()
     except Registration.DoesNotExist:
         # Catch the case where the registration is already deleted


### PR DESCRIPTION
Since registrations contain personal information the table, instead of first removing the user, we delete the complete registration.