### PR TITLE
Fine tune participant transitions

### DIFF
--- a/bluebottle/time_based/states/participants.py
+++ b/bluebottle/time_based/states/participants.py
@@ -514,7 +514,7 @@ class TeamScheduleParticipantStateMachine(ScheduleParticipantStateMachine):
 
 @register(PeriodicParticipant)
 class PeriodicParticipantStateMachine(RegistrationParticipantStateMachine):
-    pass
+    withdraw = None
 
 
 @register(DateParticipant)

--- a/bluebottle/time_based/states/registrations.py
+++ b/bluebottle/time_based/states/registrations.py
@@ -81,7 +81,7 @@ class RegistrationStateMachine(ModelStateMachine):
     )
 
     reject = Transition(
-        [new, accepted],
+        new,
         rejected,
         name=_('Reject'),
         description=_("Reject this person as a participant of this activity."),

--- a/bluebottle/time_based/tests/test_participant_triggers.py
+++ b/bluebottle/time_based/tests/test_participant_triggers.py
@@ -341,6 +341,15 @@ class PeriodicParticipantTriggerCase(ParticipantTriggerTestCase, BluebottleTestC
         # Skip this test for periodic activity
         pass
 
+    def test_withdraw(self):
+        pass
+
+    def test_withdraw_unfill(self):
+        pass
+
+    def test_reapply(self):
+        pass
+
     def test_fill_unfill(self):
         self.activity.capacity = 1
         self.activity.save()
@@ -386,15 +395,6 @@ class ScheduleParticipantTriggerCase(ParticipantTriggerTestCase, BluebottleTestC
 
         self.activity.refresh_from_db()
         self.assertEqual(self.activity.status, "full")
-
-    def test_withdraw_unfill(self):
-        self.activity.capacity = 1
-        self.activity.save()
-
-        self.test_withdraw()
-
-        self.activity.refresh_from_db()
-        self.assertEqual(self.activity.status, "open")
 
     def test_remove_unfill(self):
         self.activity.capacity = 1

--- a/bluebottle/time_based/tests/test_registration_triggers.py
+++ b/bluebottle/time_based/tests/test_registration_triggers.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from django.core import mail
 from django.utils.timezone import now
 
+from bluebottle.fsm.state import TransitionNotPossible
 from bluebottle.initiatives.tests.factories import (
     InitiativeFactory,
     InitiativePlatformSettingsFactory,
@@ -256,10 +257,7 @@ class DateRegistrationTriggerTestCase(
         super().test_accept()
         self.slot.start = now() - timedelta(days=3)
         self.slot.save()
-        self.registration.states.reject(save=True)
-        self.assertStatus(self.registration, "rejected")
-        self.assertStatus(self.participant, "rejected")
-        self.assertStatus(self.contribution, "failed")
+        self.assertRaises(TransitionNotPossible, self.registration.states.reject)
 
     def test_fill(self):
         self.slot.capacity = 1

--- a/bluebottle/time_based/tests/test_scenarios.py
+++ b/bluebottle/time_based/tests/test_scenarios.py
@@ -210,27 +210,29 @@ class DateParticipantScenarioTestCase(BluebottleTestCase):
             self, self.activity, self.supporter, status="accepted"
         )
         assert_status(self, model=self.activity, status="full")
-        api_registration_transition(
+        api_participant_transition(
             self,
-            self.activity,
+            self.slot1,
             self.supporter,
-            transition="reject",
-            request_user=self.activity.owner,
-        )
-        assert_registration_status(
-            self, self.activity, self.supporter, status="rejected"
-        )
-        assert_status(self, model=self.activity, status="open")
-        api_registration_transition(
-            self,
-            self.activity,
-            self.supporter,
-            transition="accept",
+            transition="remove",
             request_user=self.activity.owner,
         )
         assert_registration_status(
             self, self.activity, self.supporter, status="accepted"
         )
+        assert_participant_status(self, self.slot1, self.supporter, status='removed')
+        assert_status(self, model=self.activity, status="open")
+        api_participant_transition(
+            self,
+            self.slot1,
+            self.supporter,
+            transition="readd",
+            request_user=self.activity.owner,
+        )
+        assert_registration_status(
+            self, self.activity, self.supporter, status="accepted"
+        )
+        assert_participant_status(self, self.slot1, self.supporter, status='accepted')
         assert_status(self, model=self.activity, status="full")
 
     def test_user_fills_slot(self):
@@ -361,8 +363,8 @@ class DateParticipantScenarioTestCase(BluebottleTestCase):
             'Slot1 should now have 2 accepted participants'
         )
         assert_status(self, self.slot2, 'full')
-        api_registration_transition(self, self.activity, supporter2, 'reject', request_user=self.owner)
-        assert_participant_status(self, self.slot2, supporter2, 'rejected')
+        api_participant_transition(self, self.slot2, supporter2, 'remove', request_user=self.owner)
+        assert_participant_status(self, self.slot2, supporter2, 'removed')
         assert_status(
             self, self.slot2, 'open',
             'Slot2 should now be open'

--- a/bluebottle/time_based/tests/test_scenarios.py
+++ b/bluebottle/time_based/tests/test_scenarios.py
@@ -126,15 +126,15 @@ class DateParticipantScenarioTestCase(BluebottleTestCase):
         )
         assert_registration_status(self, self.activity, self.supporter, status='accepted')
         assert_participant_status(self, slot, self.supporter, status='accepted')
-        api_registration_transition(
+        api_participant_transition(
             self, self.activity, self.supporter,
-            transition='reject', request_user=self.owner
+            transition='remove', request_user=self.owner
         )
-        assert_registration_status(self, self.activity, self.supporter, status='rejected')
-        assert_participant_status(self, slot, self.supporter, status='rejected')
-        api_registration_transition(
+        assert_registration_status(self, self.activity, self.supporter, status='accepted')
+        assert_participant_status(self, slot, self.supporter, status='removed')
+        api_participant_transition(
             self, self.activity, self.supporter,
-            transition='accept', request_user=self.owner
+            transition='readd', request_user=self.owner
         )
         assert_registration_status(self, self.activity, self.supporter, status='accepted')
         assert_participant_status(self, slot, self.supporter, status='accepted')
@@ -248,14 +248,14 @@ class DateParticipantScenarioTestCase(BluebottleTestCase):
         api_participant_transition(self, self.slot1, self.supporter, transition='reapply')
         assert_participant_status(self, self.slot1, self.supporter, status='accepted')
         assert_status(self, self.slot1, 'full')
-        api_registration_transition(
-            self, self.activity, self.supporter, transition='reject', request_user=self.owner
+        api_participant_transition(
+            self, self.activity, self.supporter, transition='remove', request_user=self.owner
         )
-        assert_registration_status(self, self.activity, self.supporter, status='rejected')
-        assert_participant_status(self, self.slot1, self.supporter, status='rejected')
+        assert_registration_status(self, self.activity, self.supporter, status='accepted')
+        assert_participant_status(self, self.slot1, self.supporter, status='removed')
         assert_status(self, self.slot1, 'open')
-        api_registration_transition(
-            self, self.activity, self.supporter, transition='accept', request_user=self.owner
+        api_participant_transition(
+            self, self.activity, self.supporter, transition='readd', request_user=self.owner
         )
         assert_registration_status(self, self.activity, self.supporter, status='accepted')
         assert_participant_status(self, self.slot1, self.supporter, status='accepted')

--- a/bluebottle/time_based/tests/test_team_triggers.py
+++ b/bluebottle/time_based/tests/test_team_triggers.py
@@ -3,6 +3,7 @@ from django.core import mail
 from bluebottle.initiatives.tests.factories import (
     InitiativeFactory,
 )
+from bluebottle.files.tests.factories import ImageFactory
 from bluebottle.test.factory_models.accounts import BlueBottleUserFactory
 from bluebottle.test.utils import BluebottleTestCase
 from bluebottle.time_based.tests.factories import (
@@ -339,7 +340,18 @@ class SecondTeamMemberTriggerTestCase(BluebottleTestCase):
         self.assertEqual(self.other_team_member.participants.get().status, "accepted")
 
     def test_reject_registration(self):
-        self.team.registration.states.reject(save=True)
+        activity = ScheduleActivityFactory.create(
+            team_activity=True, initiative=None, review=True, image=ImageFactory.create()
+        )
+        activity.states.approve(save=True)
+
+        self.registration = TeamScheduleRegistrationFactory.create(user=self.captain)
+        self.team = TeamFactory.create(activity=activity, user=self.captain, registration=self.registration)
+        self.other_team = TeamFactory.create(activity=activity, user=self.captain, registration=self.registration)
+        self.team_member = TeamMemberFactory.create(team=self.team)
+        self.other_team_member = TeamMemberFactory.create(team=self.other_team)
+
+        self.registration.states.reject(save=True)
 
         self.team.refresh_from_db()
         self.other_team.refresh_from_db()


### PR DESCRIPTION
- You cannot withdraw from periodic activities, only set_cropbox
- After accepting a participant, you cannout reject them, only remove them.